### PR TITLE
Don't try and directly invoke git in builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,13 +73,6 @@ def verifyLocalProperties = {
 }
 
 def generateKeystore(keystoreFile) {
-    def userNameOut = new ByteArrayOutputStream()
-    exec {
-        executable "git"
-        args "config", "--get", "user.name"
-        standardOutput = userNameOut
-    }
-    def userName = new String(userNameOut.toByteArray())
     exec {
         executable "keytool"
         args "-genkey",
@@ -90,7 +83,7 @@ def generateKeystore(keystoreFile) {
             "-validity", "10000",
             "-keypass", "appauth",
             "-storepass", "appauth",
-            "-dname", "CN=${userName}"
+            "-dname", "CN=appauth"
     }
 }
 


### PR DESCRIPTION
The build script was trying to populate the auto-generated keystore
with the right user name in the CN= field, by retrieving the user's
name from the git config. With some configurations, this just plain
won't work. So, don't try and be so clever, just use "appauth" as
the name, given it is of no real consequence.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/5)
<!-- Reviewable:end -->
