### PR TITLE
Test coverage and fixes for AuthState

### DIFF
--- a/library/javatests/net/openid/appauth/TestValues.java
+++ b/library/javatests/net/openid/appauth/TestValues.java
@@ -34,6 +34,7 @@ class TestValues {
     public static final String TEST_CODE_VERIFIER = "0123456789_0123456789_0123456789_0123456789";
     public static final String TEST_AUTH_CODE = "zxcvbnmjk";
     public static final String TEST_ACCESS_TOKEN = "aaabbbccc";
+    public static final Long TEST_ACCESS_TOKEN_EXPIRATION_TIME = 120000L; // two minutes
     public static final String TEST_ID_TOKEN = "abc.def.ghi";
     public static final String TEST_REFRESH_TOKEN = "asdfghjkl";
 
@@ -43,12 +44,16 @@ class TestValues {
                 TEST_IDP_TOKEN_ENDPOINT);
     }
 
-    public static AuthorizationRequest.Builder getTestAuthRequestBuilder() {
+    public static AuthorizationRequest.Builder getMinimalAuthRequestBuilder(String responseType) {
         return new AuthorizationRequest.Builder(
                 getTestServiceConfig(),
                 TEST_CLIENT_ID,
-                AuthorizationRequest.RESPONSE_TYPE_CODE,
-                TEST_APP_REDIRECT_URI)
+                responseType,
+                TEST_APP_REDIRECT_URI);
+    }
+
+    public static AuthorizationRequest.Builder getTestAuthRequestBuilder() {
+        return getMinimalAuthRequestBuilder(AuthorizationRequest.RESPONSE_TYPE_CODE)
                 .setScopes(AuthorizationRequest.SCOPE_OPENID, AuthorizationRequest.SCOPE_EMAIL)
                 .setCodeVerifier(TEST_CODE_VERIFIER);
     }
@@ -57,8 +62,23 @@ class TestValues {
         return getTestAuthRequestBuilder().build();
     }
 
+    public static AuthorizationResponse.Builder getTestAuthResponseBuilder() {
+        AuthorizationRequest req = getTestAuthRequest();
+        return new AuthorizationResponse.Builder(req)
+                .setState(req.state)
+                .setAuthorizationCode(TEST_AUTH_CODE);
+    }
+
+    public static AuthorizationResponse getTestAuthResponse() {
+        return getTestAuthResponseBuilder().build();
+    }
+
+    public static TokenRequest.Builder getMinimalTokenRequestBuilder() {
+        return new TokenRequest.Builder(getTestServiceConfig(), TEST_CLIENT_ID);
+    }
+
     public static TokenRequest.Builder getTestAuthCodeExchangeRequestBuilder() {
-        return new TokenRequest.Builder(getTestServiceConfig(), TEST_CLIENT_ID)
+        return getMinimalTokenRequestBuilder()
                 .setAuthorizationCode(TEST_AUTH_CODE)
                 .setCodeVerifier(TEST_CODE_VERIFIER)
                 .setGrantType(TokenRequest.GRANT_TYPE_AUTHORIZATION_CODE)
@@ -67,5 +87,15 @@ class TestValues {
 
     public static TokenRequest getTestAuthCodeExchangeRequest() {
         return getTestAuthCodeExchangeRequestBuilder().build();
+    }
+
+    public static TokenResponse.Builder getTestAuthCodeExchangeResponseBuilder() {
+        return new TokenResponse.Builder(getTestAuthCodeExchangeRequest())
+                .setTokenType(TokenResponse.TOKEN_TYPE_BEARER)
+                .setRefreshToken(TEST_REFRESH_TOKEN);
+    }
+
+    public static TokenResponse getTestAuthCodeExchangeResponse() {
+        return getTestAuthCodeExchangeResponseBuilder().build();
     }
 }


### PR DESCRIPTION
@WilliamDenniss - testing uncovered some subtle bugs around our utility methods for tokens and token expiry, where tokens returned on the authorization response can be hidden by those on subsequent token responses. I don't know if this is a real problem, but I think the spec seems flexible in this regard. So, I made some changes to check the auth response for a token value if it is not found on the token response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/35) &emsp; Multiple assignees:&emsp;<img alt="@WilliamDenniss" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/445150?s=40&v=3">&nbsp;<a href="/openid/appauth-android/pulls/assigned/WilliamDenniss">WilliamDenniss</a>,&emsp;<img alt="@tikurahul" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/624211?s=40&v=3">&nbsp;<a href="/openid/appauth-android/pulls/assigned/tikurahul">tikurahul</a>
<!-- Reviewable:end -->
