### PR TITLE
Be less opinionated about the token request URI

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -176,13 +176,12 @@ public class AuthorizationService {
      * callback handler.
      */
     public void performTokenRequest(
-            @NonNull net.openid.appauth.TokenRequest request,
+            @NonNull TokenRequest request,
             @NonNull TokenResponseCallback callback) {
         checkNotDisposed();
         Logger.debug("Initiating code exchange request to %s",
                 request.configuration.tokenEndpoint);
-        new TokenRequestTask(request.toUri(), request, callback)
-                .execute();
+        new TokenRequestTask(request, callback).execute();
     }
 
     /**
@@ -206,32 +205,24 @@ public class AuthorizationService {
 
     private class TokenRequestTask
             extends AsyncTask<Void, Void, JSONObject> {
-        private Uri mRequestUri;
-        private net.openid.appauth.TokenRequest mRequest;
+        private TokenRequest mRequest;
         private TokenResponseCallback mCallback;
 
         private AuthorizationException mException;
 
-        TokenRequestTask(Uri requestUri,
-                         net.openid.appauth.TokenRequest request,
+        TokenRequestTask(TokenRequest request,
                          TokenResponseCallback callback) {
-            mRequestUri = requestUri;
             mRequest = request;
             mCallback = callback;
         }
 
         @Override
         protected JSONObject doInBackground(Void... voids) {
-            String queryData = mRequestUri.getEncodedQuery();
+            String queryData = mRequest.getFormUrlEncodedRequestBody();
             InputStream is = null;
             try {
-                /*
-                 * TODO: handle MalformedUrlException from url construction separately
-                 * this is usually indicative of programmer error rather than network error
-                 */
-                URL url = mUrlBuilder.buildUrlFromString(mRequestUri.getScheme()
-                        + "://" + mRequestUri.getHost()
-                        + mRequestUri.getPath());
+                URL url = mUrlBuilder.buildUrlFromString(
+                        mRequest.configuration.tokenEndpoint.toString());
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("POST");
 

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -171,7 +171,7 @@ public class AuthorizationServiceTest {
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
         String postBody = mOutputStream.toString();
-        assertThat(postBody).isEqualTo(request.toUri().getEncodedQuery());
+        assertThat(postBody).isEqualTo(request.getFormUrlEncodedRequestBody());
         assertEquals(TEST_IDP_TOKEN_ENDPOINT.toString(), mBuilder.mUri);
     }
 

--- a/library/javatests/net/openid/appauth/TokenRequestTest.java
+++ b/library/javatests/net/openid/appauth/TokenRequestTest.java
@@ -18,10 +18,7 @@ import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
 import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
 import static net.openid.appauth.TestValues.TEST_CODE_VERIFIER;
 import static net.openid.appauth.TestValues.getTestServiceConfig;
-import static org.assertj.android.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import android.net.Uri;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,11 +53,13 @@ public class TokenRequestTest {
                 .setRedirectUri(TEST_APP_REDIRECT_URI);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void testBuild_nullConfiguration() {
         new TokenRequest.Builder(null, TEST_CLIENT_ID).build();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test(expected = IllegalArgumentException.class)
     public void testBuild_nullClientId() {
         new TokenRequest.Builder(getTestServiceConfig(), null)
@@ -121,19 +120,19 @@ public class TokenRequestTest {
     public void testToUri_forCodeExchange() {
         TokenRequest request = mAuthorizationCodeRequestBuilder.build();
 
-        Uri requestUri = request.toUri();
-        assertThat(requestUri)
-                .hasScheme(request.configuration.tokenEndpoint.getScheme())
-                .hasHost(request.configuration.tokenEndpoint.getHost());
-        requestUri.getAuthority();
-        assertThat(requestUri.getQueryParameter(TokenRequest.PARAM_GRANT_TYPE))
-                .isEqualTo(TokenRequest.GRANT_TYPE_AUTHORIZATION_CODE);
-        assertThat(requestUri.getQueryParameter(TokenRequest.PARAM_CLIENT_ID))
-                .isEqualTo(TEST_CLIENT_ID);
-        assertThat(requestUri.getQueryParameter(TokenRequest.PARAM_CODE))
-                .isEqualTo(TEST_AUTHORIZATION_CODE);
-        assertThat(requestUri.getQueryParameter(TokenRequest.PARAM_REDIRECT_URI))
-                .isEqualTo(TEST_APP_REDIRECT_URI.toString());
+        Map<String, String> params = request.getRequestParameters();
+        assertThat(params).containsEntry(
+                TokenRequest.PARAM_GRANT_TYPE,
+                TokenRequest.GRANT_TYPE_AUTHORIZATION_CODE);
+        assertThat(params).containsEntry(
+                TokenRequest.PARAM_CLIENT_ID,
+                TEST_CLIENT_ID);
+        assertThat(params).containsEntry(
+                TokenRequest.PARAM_CODE,
+                TEST_AUTHORIZATION_CODE);
+        assertThat(params).containsEntry(
+                TokenRequest.PARAM_REDIRECT_URI,
+                TEST_APP_REDIRECT_URI.toString());
     }
 
     @Test
@@ -142,13 +141,16 @@ public class TokenRequestTest {
                 .setRefreshToken(TEST_REFRESH_TOKEN)
                 .build();
 
-        Uri requestUri = request.toUri();
-        assertThat(requestUri.getQueryParameter(TokenRequest.PARAM_GRANT_TYPE))
-                .isEqualTo(TokenRequest.GRANT_TYPE_REFRESH_TOKEN);
-        assertThat(requestUri.getQueryParameter(TokenRequest.PARAM_CLIENT_ID))
-                .isEqualTo(TEST_CLIENT_ID);
-        assertThat(requestUri.getQueryParameter(TokenRequest.PARAM_REFRESH_TOKEN))
-                .isEqualTo(TEST_REFRESH_TOKEN);
+        Map<String, String> params = request.getRequestParameters();
+        assertThat(params).containsEntry(
+                TokenRequest.PARAM_GRANT_TYPE,
+                TokenRequest.GRANT_TYPE_REFRESH_TOKEN);
+        assertThat(params).containsEntry(
+                TokenRequest.PARAM_CLIENT_ID,
+                TEST_CLIENT_ID);
+        assertThat(params).containsEntry(
+                TokenRequest.PARAM_REFRESH_TOKEN,
+                TEST_REFRESH_TOKEN);
     }
 
     @Test
@@ -157,8 +159,8 @@ public class TokenRequestTest {
                 .setCodeVerifier(TEST_CODE_VERIFIER)
                 .build();
 
-        assertThat(request.toUri().getQueryParameter(TokenRequest.PARAM_CODE_VERIFIER))
-                .isEqualTo(TEST_CODE_VERIFIER);
+        assertThat(request.getRequestParameters())
+                .containsEntry(TokenRequest.PARAM_CODE_VERIFIER, TEST_CODE_VERIFIER);
     }
 
     @Test
@@ -168,8 +170,8 @@ public class TokenRequestTest {
                 .setScope("email profile")
                 .build();
 
-        assertThat(request.toUri().getQueryParameter(TokenRequest.PARAM_SCOPE))
-                .isEqualTo("email profile");
+        assertThat(request.getRequestParameters())
+                .containsEntry(TokenRequest.PARAM_SCOPE, "email profile");
     }
 
     @Test
@@ -181,8 +183,8 @@ public class TokenRequestTest {
                 .setAdditionalParameters(additionalParams)
                 .build();
 
-        Uri requestUri = request.toUri();
-        assertThat(requestUri.getQueryParameter("p1")).isEqualTo("v1");
-        assertThat(requestUri.getQueryParameter("p2")).isEqualTo("v2");
+        Map<String, String> params = request.getRequestParameters();
+        assertThat(params).containsEntry("p1", "v1");
+        assertThat(params).containsEntry("p2", "v2");
     }
 }


### PR DESCRIPTION
The URI used for token requests was previously build from components of the actual URI provided by the provider configuration. This was partly through being over-opinionated about the structure of token URIs, but also to avoid mixing any parameters set on the token URI with those that would ultimately have been sent in the request body, as a side-effect of the way the body was being constructed. This decouples the two concerns, allowing the token URI to be used as-is from the configuration, while building the request body using a clean URI builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/37) &emsp; Multiple assignees:&emsp;<img alt="@WilliamDenniss" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/445150?s=40&v=3">&nbsp;<a href="/openid/appauth-android/pulls/assigned/WilliamDenniss">WilliamDenniss</a>,&emsp;<img alt="@tikurahul" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/624211?s=40&v=3">&nbsp;<a href="/openid/appauth-android/pulls/assigned/tikurahul">tikurahul</a>
<!-- Reviewable:end -->
