### PR TITLE
[WIP] OpenID Connect Dynamic Client Registration support

### DIFF
--- a/app/src/net/openid/appauthdemo/IdentityProvider.java
+++ b/app/src/net/openid/appauthdemo/IdentityProvider.java
@@ -49,7 +49,6 @@ class IdentityProvider {
             NOT_SPECIFIED, // token endpoint is discovered
             NOT_SPECIFIED, // dynamic registration not supported
             R.string.google_client_id,
-            NOT_SPECIFIED, // client_secret not used
             R.string.google_auth_redirect_uri,
             R.string.google_scope_string,
             R.drawable.btn_google,
@@ -99,9 +98,6 @@ class IdentityProvider {
     private final int mClientIdRes;
 
     @StringRes
-    private final int mClientSecretRes;
-
-    @StringRes
     private final int mRedirectUriRes;
 
     @StringRes
@@ -126,7 +122,6 @@ class IdentityProvider {
             @StringRes int tokenEndpointRes,
             @StringRes int registrationEndpointRes,
             @StringRes int clientIdRes,
-            @StringRes int clientSecretRes,
             @StringRes int redirectUriRes,
             @StringRes int scopeRes,
             @DrawableRes int buttonImageRes,
@@ -146,7 +141,6 @@ class IdentityProvider {
         this.mTokenEndpointRes = tokenEndpointRes;
         this.mRegistrationEndpointRes = registrationEndpointRes;
         this.mClientIdRes = clientIdRes;
-        this.mClientSecretRes = clientSecretRes;
         this.mRedirectUriRes = checkSpecified(redirectUriRes, "redirectUriRes");
         this.mScopeRes = checkSpecified(scopeRes, "scopeRes");
         this.buttonImageRes = checkSpecified(buttonImageRes, "buttonImageRes");
@@ -180,9 +174,6 @@ class IdentityProvider {
                 : null;
         mClientId = isSpecified(mClientIdRes)
                 ? res.getString(mClientIdRes)
-                : null;
-        mClientSecret = isSpecified(mClientSecretRes)
-                ? res.getString(mClientSecretRes)
                 : null;
         mRedirectUri = getUriResource(res, mRedirectUriRes, "mRedirectUriRes");
         mScope = res.getString(mScopeRes);
@@ -226,7 +217,6 @@ class IdentityProvider {
 
     @Nullable
     public String getClientSecret() {
-        checkConfigurationRead();
         return mClientSecret;
     }
 

--- a/app/src/net/openid/appauthdemo/IdentityProvider.java
+++ b/app/src/net/openid/appauthdemo/IdentityProvider.java
@@ -49,6 +49,7 @@ class IdentityProvider {
             NOT_SPECIFIED, // token endpoint is discovered
             NOT_SPECIFIED, // dynamic registration not supported
             R.string.google_client_id,
+            NOT_SPECIFIED, // client_secret not used
             R.string.google_auth_redirect_uri,
             R.string.google_scope_string,
             R.drawable.btn_google,
@@ -98,6 +99,9 @@ class IdentityProvider {
     private final int mClientIdRes;
 
     @StringRes
+    private final int mClientSecretRes;
+
+    @StringRes
     private final int mRedirectUriRes;
 
     @StringRes
@@ -110,6 +114,7 @@ class IdentityProvider {
     private Uri mTokenEndpoint;
     private Uri mRegistrationEndpoint;
     private String mClientId;
+    private String mClientSecret;
     private Uri mRedirectUri;
     private String mScope;
 
@@ -121,6 +126,7 @@ class IdentityProvider {
             @StringRes int tokenEndpointRes,
             @StringRes int registrationEndpointRes,
             @StringRes int clientIdRes,
+            @StringRes int clientSecretRes,
             @StringRes int redirectUriRes,
             @StringRes int scopeRes,
             @DrawableRes int buttonImageRes,
@@ -139,7 +145,8 @@ class IdentityProvider {
         this.mAuthEndpointRes = authEndpointRes;
         this.mTokenEndpointRes = tokenEndpointRes;
         this.mRegistrationEndpointRes = registrationEndpointRes;
-        this.mClientIdRes = checkSpecified(clientIdRes, "clientIdRes");
+        this.mClientIdRes = clientIdRes;
+        this.mClientSecretRes = clientSecretRes;
         this.mRedirectUriRes = checkSpecified(redirectUriRes, "redirectUriRes");
         this.mScopeRes = checkSpecified(scopeRes, "scopeRes");
         this.buttonImageRes = checkSpecified(buttonImageRes, "buttonImageRes");
@@ -171,7 +178,12 @@ class IdentityProvider {
         mRegistrationEndpoint = isSpecified(mRegistrationEndpointRes)
                 ? getUriResource(res, mRegistrationEndpointRes, "registrationEndpointRes")
                 : null;
-        mClientId = res.getString(mClientIdRes);
+        mClientId = isSpecified(mClientIdRes)
+                ? res.getString(mClientIdRes)
+                : null;
+        mClientSecret = isSpecified(mClientSecretRes)
+                ? res.getString(mClientSecretRes)
+                : null;
         mRedirectUri = getUriResource(res, mRedirectUriRes, "mRedirectUriRes");
         mScope = res.getString(mScopeRes);
 
@@ -207,10 +219,23 @@ class IdentityProvider {
         return mTokenEndpoint;
     }
 
-    @NonNull
     public String getClientId() {
         checkConfigurationRead();
         return mClientId;
+    }
+
+    @Nullable
+    public String getClientSecret() {
+        checkConfigurationRead();
+        return mClientSecret;
+    }
+
+    public void setClientId(String clientId) {
+        mClientId = clientId;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        mClientSecret = clientSecret;
     }
 
     @NonNull

--- a/app/src/net/openid/appauthdemo/IdentityProvider.java
+++ b/app/src/net/openid/appauthdemo/IdentityProvider.java
@@ -47,6 +47,7 @@ class IdentityProvider {
             R.string.google_discovery_uri,
             NOT_SPECIFIED, // auth endpoint is discovered
             NOT_SPECIFIED, // token endpoint is discovered
+            NOT_SPECIFIED, // dynamic registration not supported
             R.string.google_client_id,
             R.string.google_auth_redirect_uri,
             R.string.google_scope_string,
@@ -91,6 +92,9 @@ class IdentityProvider {
     private final int mTokenEndpointRes;
 
     @StringRes
+    private final int mRegistrationEndpointRes;
+
+    @StringRes
     private final int mClientIdRes;
 
     @StringRes
@@ -104,6 +108,7 @@ class IdentityProvider {
     private Uri mDiscoveryEndpoint;
     private Uri mAuthEndpoint;
     private Uri mTokenEndpoint;
+    private Uri mRegistrationEndpoint;
     private String mClientId;
     private Uri mRedirectUri;
     private String mScope;
@@ -114,6 +119,7 @@ class IdentityProvider {
             @StringRes int discoveryEndpointRes,
             @StringRes int authEndpointRes,
             @StringRes int tokenEndpointRes,
+            @StringRes int registrationEndpointRes,
             @StringRes int clientIdRes,
             @StringRes int redirectUriRes,
             @StringRes int scopeRes,
@@ -132,6 +138,7 @@ class IdentityProvider {
         this.mDiscoveryEndpointRes = discoveryEndpointRes;
         this.mAuthEndpointRes = authEndpointRes;
         this.mTokenEndpointRes = tokenEndpointRes;
+        this.mRegistrationEndpointRes = registrationEndpointRes;
         this.mClientIdRes = checkSpecified(clientIdRes, "clientIdRes");
         this.mRedirectUriRes = checkSpecified(redirectUriRes, "redirectUriRes");
         this.mScopeRes = checkSpecified(scopeRes, "scopeRes");
@@ -160,6 +167,9 @@ class IdentityProvider {
                 : null;
         mTokenEndpoint = isSpecified(mTokenEndpointRes)
                 ? getUriResource(res, mTokenEndpointRes, "tokenEndpointRes")
+                : null;
+        mRegistrationEndpoint = isSpecified(mRegistrationEndpointRes)
+                ? getUriResource(res, mRegistrationEndpointRes, "registrationEndpointRes")
                 : null;
         mClientId = res.getString(mClientIdRes);
         mRedirectUri = getUriResource(res, mRedirectUriRes, "mRedirectUriRes");
@@ -222,7 +232,8 @@ class IdentityProvider {
             AuthorizationServiceConfiguration.fetchFromUrl(mDiscoveryEndpoint, callback);
         } else {
             AuthorizationServiceConfiguration config =
-                    new AuthorizationServiceConfiguration(mAuthEndpoint, mTokenEndpoint);
+                    new AuthorizationServiceConfiguration(mAuthEndpoint, mTokenEndpoint,
+                            mRegistrationEndpoint);
             callback.onFetchConfigurationCompleted(config, null);
         }
     }

--- a/app/src/net/openid/appauthdemo/MainActivity.java
+++ b/app/src/net/openid/appauthdemo/MainActivity.java
@@ -33,6 +33,7 @@ import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationRequest;
 import net.openid.appauth.AuthorizationService;
 import net.openid.appauth.AuthorizationServiceConfiguration;
+import net.openid.appauth.ResponseTypeValues;
 
 import java.util.List;
 
@@ -122,7 +123,7 @@ public class MainActivity extends AppCompatActivity {
         AuthorizationRequest authRequest = new AuthorizationRequest.Builder(
                 serviceConfig,
                 idp.getClientId(),
-                AuthorizationRequest.RESPONSE_TYPE_CODE,
+                ResponseTypeValues.CODE,
                 idp.getRedirectUri())
                 .setScope(idp.getScope())
                 .build();

--- a/app/src/net/openid/appauthdemo/MainActivity.java
+++ b/app/src/net/openid/appauthdemo/MainActivity.java
@@ -33,8 +33,11 @@ import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationRequest;
 import net.openid.appauth.AuthorizationService;
 import net.openid.appauth.AuthorizationServiceConfiguration;
+import net.openid.appauth.RegistrationRequest;
+import net.openid.appauth.RegistrationResponse;
 import net.openid.appauth.ResponseTypeValues;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -77,7 +80,12 @@ public class MainActivity extends AppCompatActivity {
                             } else {
                                 Log.d(TAG, "configuration retrieved for " + idp.name
                                         + ", proceeding");
-                                makeAuthRequest(serviceConfiguration, idp);
+                                if (idp.getClientId() == null) {
+                                    // Do dynamic client registration if no client_id
+                                    makeRegistrationRequest(serviceConfiguration, idp);
+                                } else {
+                                    makeAuthRequest(serviceConfiguration, idp);
+                                }
                             }
                         }
                     };
@@ -139,6 +147,34 @@ public class MainActivity extends AppCompatActivity {
                         .setToolbarColor(getColorCompat(R.color.colorAccent))
                         .build());
     }
+
+    private void makeRegistrationRequest(
+            @NonNull AuthorizationServiceConfiguration serviceConfig,
+            @NonNull final IdentityProvider idp) {
+        final RegistrationRequest registrationRequest = new RegistrationRequest.Builder(
+                serviceConfig,
+                Arrays.asList(idp.getRedirectUri()))
+                .build();
+        Log.d(TAG, "Making registration request to " + serviceConfig.registrationEndpoint);
+        mAuthService.performRegistrationRequest(
+                registrationRequest,
+                new AuthorizationService.RegistrationResponseCallback() {
+                    @Override
+                    public void onRegistrationRequestCompleted(
+                            @Nullable RegistrationResponse registrationResponse,
+                            @Nullable AuthorizationException ex) {
+                        Log.d(TAG, "Registration request complete");
+                        if (registrationResponse != null) {
+                            idp.setClientId(registrationResponse.clientId);
+                            idp.setClientSecret(registrationResponse.clientSecret);
+                            Log.d(TAG, "Registration request complete successfully");
+                            // Continue with the authentication
+                            makeAuthRequest(registrationResponse.request.configuration, idp);
+                        }
+                    }
+                });
+    }
+
 
     @TargetApi(Build.VERSION_CODES.M)
     @SuppressWarnings("deprecation")

--- a/library/java/net/openid/appauth/AuthState.java
+++ b/library/java/net/openid/appauth/AuthState.java
@@ -431,7 +431,7 @@ public class AuthState {
         return new TokenRequest.Builder(
                 mLastAuthorizationResponse.request.configuration,
                 mLastAuthorizationResponse.request.clientId)
-                .setGrantType(TokenRequest.GRANT_TYPE_REFRESH_TOKEN)
+                .setGrantType(GrantTypeValues.REFRESH_TOKEN)
                 .setScope(mLastAuthorizationResponse.request.scope)
                 .setRefreshToken(mRefreshToken)
                 .setAdditionalParameters(additionalParameters)

--- a/library/java/net/openid/appauth/AuthorizationException.java
+++ b/library/java/net/openid/appauth/AuthorizationException.java
@@ -115,6 +115,11 @@ public final class AuthorizationException extends Exception {
     public static final int TYPE_OAUTH_TOKEN_ERROR = 2;
 
     /**
+     * The error type for OAuth specific errors on the registration endpoint.
+     */
+    public static final int TYPE_OAUTH_REGISTRATION_ERROR = 3;
+
+    /**
      * The error type for authorization errors encountered out of band on the resource server.
      */
     public static final int TYPE_RESOURCE_SERVER_AUTHORIZATION_ERROR = 3;
@@ -188,6 +193,12 @@ public final class AuthorizationException extends Exception {
          */
         public static final AuthorizationException TOKEN_RESPONSE_CONSTRUCTION_ERROR =
                 generalEx(6, "Token response construction error");
+
+        /**
+         * Indicates a problem parsing an OpenID Connect Registration Response.
+         */
+        public static final AuthorizationException INVALID_REGISTRATION_RESPONSE =
+                generalEx(7, "Invalid registration response");
     }
 
     /**
@@ -368,6 +379,67 @@ public final class AuthorizationException extends Exception {
         }
     }
 
+    /**
+     * Error codes related to failed registration requests.
+     */
+    public static final class RegistrationRequestErrors {
+        // codes in this group should be between 3000-3999
+
+        /**
+         * An {@code invalid_request} OAuth2 error response.
+         */
+        public static final AuthorizationException INVALID_REQUEST =
+                registrationEx(3000, "invalid_request");
+
+        /**
+         * An {@code invalid_client} OAuth2 error response.
+         */
+        public static final AuthorizationException INVALID_REDIRECT_URI =
+                registrationEx(3001, "invalid_redirect_uri");
+
+        /**
+         * An {@code invalid_grant} OAuth2 error response.
+         */
+        public static final AuthorizationException INVALID_CLIENT_METADATA =
+                registrationEx(3002, "invalid_client_metadata");
+
+        /**
+         * An authorization error occurring on the client rather than the server. For example,
+         * due to client misconfiguration. This error should be treated as unrecoverable.
+         */
+        public static final AuthorizationException CLIENT_ERROR =
+                registrationEx(3003, null);
+
+        /**
+         * Indicates an OAuth error as per RFC 6749, but the error code is not known to the
+         * AppAuth for Android library. It could be a custom error or code, or one from an
+         * OAuth extension. The {@link #error} field provides the exact error string returned by
+         * the server.
+         */
+        public static final AuthorizationException OTHER =
+                registrationEx(3004, null);
+
+        private static final Map<String, AuthorizationException> STRING_TO_EXCEPTION =
+                exceptionMapByString(
+                        INVALID_REQUEST,
+                        INVALID_REDIRECT_URI,
+                        INVALID_CLIENT_METADATA,
+                        CLIENT_ERROR,
+                        OTHER);
+
+        /**
+         * Returns the matching exception type for the provided OAuth2 error string, or
+         * {@link #OTHER} if unknown.
+         */
+        public static AuthorizationException byString(String error) {
+            AuthorizationException ex = STRING_TO_EXCEPTION.get(error);
+            if (ex != null) {
+                return ex;
+            }
+            return OTHER;
+        }
+    }
+
     private static AuthorizationException generalEx(int code, @Nullable String errorDescription) {
         return new AuthorizationException(
                 TYPE_GENERAL_ERROR, code, null, errorDescription, null, null);
@@ -381,6 +453,11 @@ public final class AuthorizationException extends Exception {
     private static AuthorizationException tokenEx(int code, @Nullable String error) {
         return new AuthorizationException(
                 TYPE_OAUTH_TOKEN_ERROR, code, error, null, null, null);
+    }
+
+    private static AuthorizationException registrationEx(int code, @Nullable String error) {
+        return new AuthorizationException(
+                TYPE_OAUTH_REGISTRATION_ERROR, code, error, null, null, null);
     }
 
     /**

--- a/library/java/net/openid/appauth/AuthorizationException.java
+++ b/library/java/net/openid/appauth/AuthorizationException.java
@@ -115,14 +115,14 @@ public final class AuthorizationException extends Exception {
     public static final int TYPE_OAUTH_TOKEN_ERROR = 2;
 
     /**
-     * The error type for OAuth specific errors on the registration endpoint.
-     */
-    public static final int TYPE_OAUTH_REGISTRATION_ERROR = 3;
-
-    /**
      * The error type for authorization errors encountered out of band on the resource server.
      */
     public static final int TYPE_RESOURCE_SERVER_AUTHORIZATION_ERROR = 3;
+
+    /**
+     * The error type for OAuth specific errors on the registration endpoint.
+     */
+    public static final int TYPE_OAUTH_REGISTRATION_ERROR = 4;
 
     @VisibleForTesting
     static final String KEY_TYPE = "type";
@@ -383,32 +383,32 @@ public final class AuthorizationException extends Exception {
      * Error codes related to failed registration requests.
      */
     public static final class RegistrationRequestErrors {
-        // codes in this group should be between 3000-3999
+        // codes in this group should be between 4000-4999
 
         /**
          * An {@code invalid_request} OAuth2 error response.
          */
         public static final AuthorizationException INVALID_REQUEST =
-                registrationEx(3000, "invalid_request");
+                registrationEx(4000, "invalid_request");
 
         /**
          * An {@code invalid_client} OAuth2 error response.
          */
         public static final AuthorizationException INVALID_REDIRECT_URI =
-                registrationEx(3001, "invalid_redirect_uri");
+                registrationEx(4001, "invalid_redirect_uri");
 
         /**
          * An {@code invalid_grant} OAuth2 error response.
          */
         public static final AuthorizationException INVALID_CLIENT_METADATA =
-                registrationEx(3002, "invalid_client_metadata");
+                registrationEx(4002, "invalid_client_metadata");
 
         /**
          * An authorization error occurring on the client rather than the server. For example,
          * due to client misconfiguration. This error should be treated as unrecoverable.
          */
         public static final AuthorizationException CLIENT_ERROR =
-                registrationEx(3003, null);
+                registrationEx(4003, null);
 
         /**
          * Indicates an OAuth error as per RFC 6749, but the error code is not known to the
@@ -417,7 +417,7 @@ public final class AuthorizationException extends Exception {
          * the server.
          */
         public static final AuthorizationException OTHER =
-                registrationEx(3004, null);
+                registrationEx(4004, null);
 
         private static final Map<String, AuthorizationException> STRING_TO_EXCEPTION =
                 exceptionMapByString(

--- a/library/java/net/openid/appauth/AuthorizationRequest.java
+++ b/library/java/net/openid/appauth/AuthorizationRequest.java
@@ -66,20 +66,6 @@ public class AuthorizationRequest {
     public static final String RESPONSE_MODE_FRAGMENT = "fragment";
 
     /**
-     * For requesting an authorization code.
-     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.1"> "The OAuth 2.0
-     * Authorization Framework" (RFC 6749), Section 3.1.1</a>
-     */
-    public static final String RESPONSE_TYPE_CODE = "code";
-
-    /**
-     * For requesting an access token via an implicit grant.
-     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.1"> "The OAuth 2.0
-     * Authorization Framework" (RFC 6749), Section 3.1.1</a>
-     */
-    public static final String RESPONSE_TYPE_TOKEN = "token";
-
-    /**
      * A scope for OpenID based authorization.
      * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">"OpenID
      * Connect Core 1.0", Section 3.1.2.1</a>
@@ -292,7 +278,7 @@ public class AuthorizationRequest {
      * The service's {@link AuthorizationServiceConfiguration configuration}.
      * This configuration specifies how to connect to a particular OAuth provider.
      * Configurations may be
-     * {@link AuthorizationServiceConfiguration#AuthorizationServiceConfiguration(Uri, Uri)}
+     * {@link AuthorizationServiceConfiguration#AuthorizationServiceConfiguration(Uri, Uri, Uri)}
      * created manually}, or {@link AuthorizationServiceConfiguration#fetchFromUrl(Uri,
      * AuthorizationServiceConfiguration.RetrieveConfigurationCallback)} via an OpenID Connect
      * Discovery Document}.

--- a/library/java/net/openid/appauth/AuthorizationResponse.java
+++ b/library/java/net/openid/appauth/AuthorizationResponse.java
@@ -467,7 +467,7 @@ public class AuthorizationResponse {
         return new TokenRequest.Builder(
                 request.configuration,
                 request.clientId)
-                .setGrantType(TokenRequest.GRANT_TYPE_AUTHORIZATION_CODE)
+                .setGrantType(GrantTypeValues.AUTHORIZATION_CODE)
                 .setRedirectUri(request.redirectUri)
                 .setScope(request.scope)
                 .setCodeVerifier(request.codeVerifier)

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -191,7 +191,7 @@ public class AuthorizationService {
      * The result of this request will be sent to the provided callback handler.
      */
     public void performRegistrationRequest(
-            @NonNull net.openid.appauth.RegistrationRequest request,
+            @NonNull RegistrationRequest request,
             @NonNull RegistrationResponseCallback callback) {
         checkNotDisposed();
         Logger.debug("Initiating dynamic client registration %s",
@@ -359,7 +359,6 @@ public class AuthorizationService {
                 // required by some providers to ensure JSON response
                 conn.setRequestProperty("Accept", "application/json");
 
-                conn.setInstanceFollowRedirects(false);
                 conn.setDoOutput(true);
                 conn.setRequestProperty("Content-Length", String.valueOf(postData.length()));
                 OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -14,6 +14,8 @@
 
 package net.openid.appauth;
 
+import static net.openid.appauth.Preconditions.checkNotNull;
+
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -38,7 +40,6 @@ import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import static net.openid.appauth.Preconditions.checkNotNull;
 
 /**
  * Dispatches requests to an OAuth2 authorization service. Note that instances of this class
@@ -350,9 +351,9 @@ public class AuthorizationService {
             InputStream is = null;
             String postData = mRequest.toJsonString();
             try {
-                URL requestURL = mUrlBuilder.buildUrlFromString(
+                URL requestUrl = mUrlBuilder.buildUrlFromString(
                         mRequest.configuration.registrationEndpoint.toString());
-                HttpURLConnection conn = (HttpURLConnection) requestURL.openConnection();
+                HttpURLConnection conn = (HttpURLConnection) requestUrl.openConnection();
                 conn.setRequestMethod("POST");
 
                 // required by some providers to ensure JSON response
@@ -410,7 +411,8 @@ public class AuthorizationService {
 
             RegistrationResponse response;
             try {
-                response = new RegistrationResponse.Builder(mRequest).fromResponseJson(json).build();
+                response = new RegistrationResponse.Builder(mRequest)
+                        .fromResponseJson(json).build();
             } catch (JSONException jsonEx) {
                 mCallback.onRegistrationRequestCompleted(null,
                         AuthorizationException.fromTemplate(
@@ -438,13 +440,14 @@ public class AuthorizationService {
     public interface RegistrationResponseCallback {
         /**
          * Invoked when the request completes successfully or fails.
-         * <p/>
+         *
          * <p>Exactly one of {@code response} or {@code ex} will be non-null. If
          * {@code response} is {@code null}, a failure occurred during the request. This can
          * happen if a bad URI was provided, no connection to the server could be established, or
-         * the response JSON was incomplete or badly formatted.
+         * the response JSON was incomplete or badly formatted.</p>
          *
-         * @param response the retrieved registration response, if successful; {@code null} otherwise.
+         * @param response the retrieved registration response, if successful; {@code null}
+         *                 otherwise.
          * @param ex       a description of the failure, if one occurred: {@code null} otherwise.
          * @see AuthorizationException.RegistrationRequestErrors
          */

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -14,8 +14,6 @@
 
 package net.openid.appauth;
 
-import static net.openid.appauth.Preconditions.checkNotNull;
-
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -28,6 +26,7 @@ import android.support.customtabs.CustomTabsIntent;
 import android.text.TextUtils;
 
 import net.openid.appauth.AuthorizationException.GeneralErrors;
+import net.openid.appauth.AuthorizationException.RegistrationRequestErrors;
 import net.openid.appauth.AuthorizationException.TokenRequestErrors;
 
 import org.json.JSONException;
@@ -38,6 +37,8 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+
+import static net.openid.appauth.Preconditions.checkNotNull;
 
 /**
  * Dispatches requests to an OAuth2 authorization service. Note that instances of this class
@@ -185,6 +186,19 @@ public class AuthorizationService {
     }
 
     /**
+     * Sends a request to the authorization service to dynamically register a client.
+     * The result of this request will be sent to the provided callback handler.
+     */
+    public void performRegistrationRequest(
+            @NonNull net.openid.appauth.RegistrationRequest request,
+            @NonNull RegistrationResponseCallback callback) {
+        checkNotDisposed();
+        Logger.debug("Initiating dynamic client registration %s",
+                request.configuration.registrationEndpoint.toString());
+        new RegistrationRequestTask(request, callback).execute();
+    }
+
+    /**
      * Disposes state that will not normally be handled by garbage collection. This should be
      * called when the authorization service is no longer required, including when any owning
      * activity is paused or destroyed (i.e. in {@link android.app.Activity#onStop()}).
@@ -316,6 +330,126 @@ public class AuthorizationService {
          */
         void onTokenRequestCompleted(@Nullable TokenResponse response,
                 @Nullable AuthorizationException ex);
+    }
+
+    private class RegistrationRequestTask
+            extends AsyncTask<Void, Void, JSONObject> {
+        private net.openid.appauth.RegistrationRequest mRequest;
+        private RegistrationResponseCallback mCallback;
+
+        private AuthorizationException mException;
+
+        RegistrationRequestTask(net.openid.appauth.RegistrationRequest request,
+                                RegistrationResponseCallback callback) {
+            mRequest = request;
+            mCallback = callback;
+        }
+
+        @Override
+        protected JSONObject doInBackground(Void... voids) {
+            InputStream is = null;
+            String postData = mRequest.toJsonString();
+            try {
+                URL requestURL = mUrlBuilder.buildUrlFromString(
+                        mRequest.configuration.registrationEndpoint.toString());
+                HttpURLConnection conn = (HttpURLConnection) requestURL.openConnection();
+                conn.setRequestMethod("POST");
+
+                // required by some providers to ensure JSON response
+                conn.setRequestProperty("Accept", "application/json");
+
+                conn.setInstanceFollowRedirects(false);
+                conn.setDoOutput(true);
+                conn.setRequestProperty("Content-Length", String.valueOf(postData.length()));
+                OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());
+                wr.write(postData);
+                wr.flush();
+
+                is = conn.getInputStream();
+                String response = Utils.readInputStream(is);
+                return new JSONObject(response);
+            } catch (IOException ex) {
+                Logger.debugWithStack(ex, "Failed to complete registration request");
+                mException = AuthorizationException.fromTemplate(
+                        GeneralErrors.NETWORK_ERROR, ex);
+            } catch (JSONException ex) {
+                Logger.debugWithStack(ex, "Failed to complete registration request");
+                mException = AuthorizationException.fromTemplate(
+                        GeneralErrors.JSON_DESERIALIZATION_ERROR, ex);
+            } finally {
+                Utils.closeQuietly(is);
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(JSONObject json) {
+            if (mException != null) {
+                mCallback.onRegistrationRequestCompleted(null, mException);
+                return;
+            }
+
+            if (json.has(AuthorizationException.PARAM_ERROR)) {
+                AuthorizationException ex;
+                try {
+                    String error = json.getString(AuthorizationException.PARAM_ERROR);
+                    ex = AuthorizationException.fromOAuthTemplate(
+                            RegistrationRequestErrors.byString(error),
+                            error,
+                            json.getString(AuthorizationException.PARAM_ERROR_DESCRIPTION),
+                            UriUtil.parseUriIfAvailable(
+                                    json.getString(AuthorizationException.PARAM_ERROR_URI)));
+                } catch (JSONException jsonEx) {
+                    ex = AuthorizationException.fromTemplate(
+                            GeneralErrors.JSON_DESERIALIZATION_ERROR,
+                            jsonEx);
+                }
+                mCallback.onRegistrationRequestCompleted(null, ex);
+                return;
+            }
+
+            RegistrationResponse response;
+            try {
+                response = new RegistrationResponse.Builder(mRequest).fromResponseJson(json).build();
+            } catch (JSONException jsonEx) {
+                mCallback.onRegistrationRequestCompleted(null,
+                        AuthorizationException.fromTemplate(
+                                GeneralErrors.JSON_DESERIALIZATION_ERROR,
+                                jsonEx));
+                return;
+            } catch (RegistrationResponse.MissingArgumentException ex) {
+                Logger.errorWithStack(ex, "Malformed registration response");
+                mException = AuthorizationException.fromTemplate(
+                        GeneralErrors.INVALID_REGISTRATION_RESPONSE,
+                        ex);
+                return;
+            }
+            Logger.debug("Dynamic registration with %s completed",
+                    mRequest.configuration.registrationEndpoint);
+            mCallback.onRegistrationRequestCompleted(response, null);
+        }
+    }
+
+    /**
+     * Callback interface for token endpoint requests.
+     *
+     * @see AuthorizationService#performTokenRequest
+     */
+    public interface RegistrationResponseCallback {
+        /**
+         * Invoked when the request completes successfully or fails.
+         * <p/>
+         * <p>Exactly one of {@code response} or {@code ex} will be non-null. If
+         * {@code response} is {@code null}, a failure occurred during the request. This can
+         * happen if a bad URI was provided, no connection to the server could be established, or
+         * the response JSON was incomplete or badly formatted.
+         *
+         * @param response the retrieved registration response, if successful; {@code null} otherwise.
+         * @param ex       a description of the failure, if one occurred: {@code null} otherwise.
+         * @see AuthorizationException.RegistrationRequestErrors
+         */
+        void onRegistrationRequestCompleted(@Nullable RegistrationResponse response,
+                                            @Nullable AuthorizationException ex);
     }
 
     @VisibleForTesting

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -335,12 +335,12 @@ public class AuthorizationService {
 
     private class RegistrationRequestTask
             extends AsyncTask<Void, Void, JSONObject> {
-        private net.openid.appauth.RegistrationRequest mRequest;
+        private RegistrationRequest mRequest;
         private RegistrationResponseCallback mCallback;
 
         private AuthorizationException mException;
 
-        RegistrationRequestTask(net.openid.appauth.RegistrationRequest request,
+        RegistrationRequestTask(RegistrationRequest request,
                                 RegistrationResponseCallback callback) {
             mRequest = request;
             mCallback = callback;

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -356,9 +356,6 @@ public class AuthorizationService {
                 HttpURLConnection conn = (HttpURLConnection) requestUrl.openConnection();
                 conn.setRequestMethod("POST");
 
-                // required by some providers to ensure JSON response
-                conn.setRequestProperty("Accept", "application/json");
-
                 conn.setDoOutput(true);
                 conn.setRequestProperty("Content-Length", String.valueOf(postData.length()));
                 OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());

--- a/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
@@ -49,6 +49,7 @@ public class AuthorizationServiceConfiguration {
 
     private static final String KEY_AUTHORIZATION_ENDPOINT = "authorizationEndpoint";
     private static final String KEY_TOKEN_ENDPOINT = "tokenEndpoint";
+    private static final String KEY_REGISTRATION_ENDPOINT = "registrationEndpoint";
     private static final String KEY_DISCOVERY_DOC = "discoveryDoc";
 
     /**
@@ -62,6 +63,13 @@ public class AuthorizationServiceConfiguration {
      */
     @NonNull
     public final Uri tokenEndpoint;
+
+    /**
+     * The authorization service's client registration endpoint.
+     */
+    @Nullable
+    public final Uri registrationEndpoint;
+
 
     /**
      * The discovery document describing the service, if it is an OpenID Connect provider.
@@ -78,9 +86,11 @@ public class AuthorizationServiceConfiguration {
      */
     public AuthorizationServiceConfiguration(
             @NonNull Uri authorizationEndpoint,
-            @NonNull Uri tokenEndpoint) {
+            @NonNull Uri tokenEndpoint,
+            @Nullable Uri registrationEndpoint) {
         this.authorizationEndpoint = checkNotNull(authorizationEndpoint);
         this.tokenEndpoint = checkNotNull(tokenEndpoint);
+        this.registrationEndpoint = registrationEndpoint;
         this.discoveryDoc = null;
     }
 
@@ -95,6 +105,7 @@ public class AuthorizationServiceConfiguration {
         this.discoveryDoc = discoveryDoc;
         this.authorizationEndpoint = discoveryDoc.getAuthorizationEndpoint();
         this.tokenEndpoint = discoveryDoc.getTokenEndpoint();
+        this.registrationEndpoint = discoveryDoc.getRegistrationEndpoint();
     }
 
     /**
@@ -105,6 +116,9 @@ public class AuthorizationServiceConfiguration {
         JSONObject json = new JSONObject();
         JsonUtil.put(json, KEY_AUTHORIZATION_ENDPOINT, authorizationEndpoint.toString());
         JsonUtil.put(json, KEY_TOKEN_ENDPOINT, tokenEndpoint.toString());
+        if (registrationEndpoint != null) {
+            JsonUtil.put(json, KEY_REGISTRATION_ENDPOINT, registrationEndpoint.toString());
+        }
         if (discoveryDoc != null) {
             JsonUtil.put(json, KEY_DISCOVERY_DOC, discoveryDoc.docJson);
         }
@@ -143,7 +157,8 @@ public class AuthorizationServiceConfiguration {
             checkArgument(json.has(KEY_TOKEN_ENDPOINT), "missing tokenEndpoint");
             return new AuthorizationServiceConfiguration(
                     JsonUtil.getUri(json, KEY_AUTHORIZATION_ENDPOINT),
-                    JsonUtil.getUri(json, KEY_TOKEN_ENDPOINT));
+                    JsonUtil.getUri(json, KEY_TOKEN_ENDPOINT),
+                    JsonUtil.getUri(json, KEY_REGISTRATION_ENDPOINT));
         }
     }
 

--- a/library/java/net/openid/appauth/GrantTypeValues.java
+++ b/library/java/net/openid/appauth/GrantTypeValues.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openid.appauth;
 
 /**

--- a/library/java/net/openid/appauth/GrantTypeValues.java
+++ b/library/java/net/openid/appauth/GrantTypeValues.java
@@ -1,0 +1,31 @@
+package net.openid.appauth;
+
+public class GrantTypeValues {
+    /**
+     * The grant type used for exchanging an authorization code for one or more tokens.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.3"> "The OAuth 2.0
+     * Authorization
+     * Framework" (RFC 6749), Section 4.1.3</a>
+     */
+    public static final String AUTHORIZATION_CODE = "authorization_code";
+
+    /**
+     * The grant type used when obtaining an access token.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.2"> "The OAuth 2.0
+     * Authorization
+     * Framework" (RFC 6749), Section 4.2</a>
+     */
+    public static final String IMPLICIT = "implicit";
+
+    /**
+     * The grant type used when exchanging a refresh token for a new token.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-6"> "The OAuth 2.0
+     * Authorization
+     * Framework" (RFC 6749), Section 6</a>
+     */
+    public static final String REFRESH_TOKEN = "refresh_token";
+
+}

--- a/library/java/net/openid/appauth/GrantTypeValues.java
+++ b/library/java/net/openid/appauth/GrantTypeValues.java
@@ -1,5 +1,10 @@
 package net.openid.appauth;
 
+/**
+ * The grant type values defined by the <a href="https://tools.ietf.org/html/rfc6749">"The OAuth 2.0
+ * Authorization Framework" (RFC 6749)</a>, and used in {@link AuthorizationRequest authorization}
+ * and {@link RegistrationRequest dynamic client registration} requests.
+ */
 public class GrantTypeValues {
     /**
      * The grant type used for exchanging an authorization code for one or more tokens.

--- a/library/java/net/openid/appauth/JsonUtil.java
+++ b/library/java/net/openid/appauth/JsonUtil.java
@@ -287,11 +287,11 @@ final class JsonUtil {
     }
 
     @NonNull
-    public static JSONArray toJsonArray(@NonNull ArrayList<String> strings) {
-        checkNotNull(strings, "strings cannot be null");
+    public static JSONArray toJsonArray(@NonNull Iterable<?> objects) {
+        checkNotNull(objects, "objects cannot be null");
         JSONArray jsonArray = new JSONArray();
-        for (String str : strings) {
-            jsonArray.put(str);
+        for (Object str : objects) {
+            jsonArray.put(str.toString());
         }
         return jsonArray;
     }

--- a/library/java/net/openid/appauth/JsonUtil.java
+++ b/library/java/net/openid/appauth/JsonUtil.java
@@ -55,6 +55,21 @@ final class JsonUtil {
     public static void put(
             @NonNull JSONObject json,
             @NonNull String field,
+            @NonNull Long value) {
+        checkNotNull(json, "json must not be null");
+        checkNotNull(field, "field must not be null");
+        checkNotNull(value, "value must not be null");
+
+        try {
+            json.put(field, value);
+        } catch (JSONException ex) {
+            throw new IllegalStateException("JSONException thrown in violation of contract, ex");
+        }
+    }
+
+    public static void put(
+            @NonNull JSONObject json,
+            @NonNull String field,
             @NonNull String value) {
         checkNotNull(json, "json must not be null");
         checkNotNull(field, "field must not be null");
@@ -192,6 +207,21 @@ final class JsonUtil {
         return value;
     }
 
+    public static List<String> getStringListIfDefined(@NonNull JSONObject json,
+                                                      @NonNull String field) throws JSONException {
+        checkNotNull(json, "json must not be null");
+        checkNotNull(field, "field must not be null");
+        if (!json.has(field)) {
+            return null;
+        }
+
+        JSONArray array = json.getJSONArray(field);
+        if (array == null) {
+            throw new JSONException("field \"" + field + "\" is mapped to a null value");
+        }
+        return toStringList(array);
+    }
+
     public static Uri getUri(
             @NonNull JSONObject json,
             @NonNull String field)
@@ -254,6 +284,20 @@ final class JsonUtil {
     }
 
     @NonNull
+    public static ArrayList<Uri> getUriList(
+            @NonNull JSONObject json,
+            @NonNull String field) throws JSONException {
+        checkNotNull(json, "json must not be null");
+        checkNotNull(field, "field must not be null");
+        if (!json.has(field)) {
+            throw new JSONException("field \"" + field + "\" not found in json object");
+        }
+
+        JSONArray array = json.getJSONArray(field);
+        return toUriList(array);
+    }
+
+    @NonNull
     public static Map<String, String> getStringMap(JSONObject json, String field)
             throws JSONException {
         LinkedHashMap<String, String> stringMap = new LinkedHashMap<>();
@@ -281,6 +325,18 @@ final class JsonUtil {
         if (jsonArray != null) {
             for (int i = 0; i < jsonArray.length(); i++) {
                 arrayList.add(checkNotNull(jsonArray.get(i)).toString());
+            }
+        }
+        return arrayList;
+    }
+
+    @NonNull
+    public static ArrayList<Uri> toUriList(@Nullable JSONArray jsonArray)
+            throws JSONException {
+        ArrayList<Uri> arrayList = new ArrayList<>();
+        if (jsonArray != null) {
+            for (int i = 0; i < jsonArray.length(); i++) {
+                arrayList.add(Uri.parse(checkNotNull(jsonArray.get(i)).toString()));
             }
         }
         return arrayList;

--- a/library/java/net/openid/appauth/JsonUtil.java
+++ b/library/java/net/openid/appauth/JsonUtil.java
@@ -55,21 +55,6 @@ final class JsonUtil {
     public static void put(
             @NonNull JSONObject json,
             @NonNull String field,
-            @NonNull Long value) {
-        checkNotNull(json, "json must not be null");
-        checkNotNull(field, "field must not be null");
-        checkNotNull(value, "value must not be null");
-
-        try {
-            json.put(field, value);
-        } catch (JSONException ex) {
-            throw new IllegalStateException("JSONException thrown in violation of contract, ex");
-        }
-    }
-
-    public static void put(
-            @NonNull JSONObject json,
-            @NonNull String field,
             @NonNull String value) {
         checkNotNull(json, "json must not be null");
         checkNotNull(field, "field must not be null");
@@ -346,8 +331,8 @@ final class JsonUtil {
     public static JSONArray toJsonArray(@NonNull Iterable<?> objects) {
         checkNotNull(objects, "objects cannot be null");
         JSONArray jsonArray = new JSONArray();
-        for (Object str : objects) {
-            jsonArray.put(str.toString());
+        for (Object obj : objects) {
+            jsonArray.put(obj.toString());
         }
         return jsonArray;
     }

--- a/library/java/net/openid/appauth/Preconditions.java
+++ b/library/java/net/openid/appauth/Preconditions.java
@@ -68,7 +68,8 @@ final class Preconditions {
      * Ensures that a collection is not null or empty.
      */
     @NonNull
-    public static <T extends Collection<?>> T checkCollectionNotEmpty(T collection, @Nullable Object errorMessage) {
+    public static <T extends Collection<?>> T checkCollectionNotEmpty(
+            T collection, @Nullable Object errorMessage) {
         checkNotNull(collection, errorMessage);
         checkArgument(!collection.isEmpty(), errorMessage);
         return collection;

--- a/library/java/net/openid/appauth/Preconditions.java
+++ b/library/java/net/openid/appauth/Preconditions.java
@@ -18,6 +18,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
+import java.util.Collection;
+
 /**
  * Utility class for guava style pre-condition checks.
  */
@@ -60,6 +62,16 @@ final class Preconditions {
     public static String checkNotEmpty(String str, @Nullable Object errorMessage) {
         checkArgument(!TextUtils.isEmpty(str), errorMessage);
         return str;
+    }
+
+    /**
+     * Ensures that a collection is not null or empty.
+     */
+    @NonNull
+    public static <T extends Collection<?>> T checkCollectionNotEmpty(T collection, @Nullable Object errorMessage) {
+        checkNotNull(collection, errorMessage);
+        checkArgument(!collection.isEmpty(), errorMessage);
+        return collection;
     }
 
     /**

--- a/library/java/net/openid/appauth/RegistrationRequest.java
+++ b/library/java/net/openid/appauth/RegistrationRequest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openid.appauth;
 
 import static net.openid.appauth.AdditionalParamsProcessor.builtInParams;

--- a/library/java/net/openid/appauth/RegistrationRequest.java
+++ b/library/java/net/openid/appauth/RegistrationRequest.java
@@ -105,9 +105,9 @@ public class RegistrationRequest {
          */
         public Builder(
                 @NonNull AuthorizationServiceConfiguration configuration,
-                @NonNull Uri redirectUri) {
+                @NonNull List<Uri> redirectUri) {
             setConfiguration(configuration);
-            setRedirectUri(redirectUri);
+            setRedirectUriValues(redirectUri);
         }
 
         /**
@@ -120,25 +120,15 @@ public class RegistrationRequest {
             return this;
         }
 
-        /**
-         * Specifies the client's redirect URI. Cannot be null or empty.
-         */
         @NonNull
-        public Builder setRedirectUri(@NonNull Uri redirectUri) {
-            return setRedirectUriValues(checkNotNull(redirectUri, "redirect URI cannot be null or empty"));
-        }
-
-        @NonNull
-        public Builder setRedirectUriValues(@Nullable Uri... redirectUriValues) {
+        public Builder setRedirectUriValues(@NonNull Uri... redirectUriValues) {
             return setRedirectUriValues(Arrays.asList(redirectUriValues));
         }
 
         @NonNull
-        public Builder setRedirectUriValues(@Nullable List<Uri> redirectUriValues) {
-            mRedirectUris.clear();
-            if (redirectUriValues != null) {
-                mRedirectUris.addAll(redirectUriValues);
-            }
+        public Builder setRedirectUriValues(@NonNull List<Uri> redirectUriValues) {
+            checkCollectionNotEmpty(redirectUriValues, "redirectUriValues cannot be null");
+            mRedirectUris = redirectUriValues;
             return this;
         }
 

--- a/library/java/net/openid/appauth/RegistrationRequest.java
+++ b/library/java/net/openid/appauth/RegistrationRequest.java
@@ -1,5 +1,11 @@
 package net.openid.appauth;
 
+import static net.openid.appauth.AdditionalParamsProcessor.builtInParams;
+import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;
+import static net.openid.appauth.Preconditions.checkCollectionNotEmpty;
+import static net.openid.appauth.Preconditions.checkNotEmpty;
+import static net.openid.appauth.Preconditions.checkNotNull;
+
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -13,14 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static net.openid.appauth.AdditionalParamsProcessor.builtInParams;
-import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;
-import static net.openid.appauth.AdditionalParamsProcessor.extractAdditionalParams;
-import static net.openid.appauth.Preconditions.checkCollectionNotEmpty;
-import static net.openid.appauth.Preconditions.checkNotEmpty;
-import static net.openid.appauth.Preconditions.checkNotNull;
-import static net.openid.appauth.Preconditions.checkNullOrNotEmpty;
 
 public class RegistrationRequest {
     /**
@@ -45,7 +43,20 @@ public class RegistrationRequest {
     static final String KEY_ADDITIONAL_PARAMETERS = "additionalParameters";
     static final String KEY_CONFIGURATION = "configuration";
 
+    /**
+     * Instructs the authorization server to generate a pairwise subject identifier.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes">
+     * "OpenID Connect Core 1.0", Section 8</a>
+     */
     public static final String SUBJECT_TYPE_PAIRWISE = "pairwise";
+
+    /**
+     * Instructs the authorization server to generate a public subject identifier.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes">
+     * "OpenID Connect Core 1.0", Section 8</a>
+     */
     public static final String SUBJECT_TYPE_PUBLIC = "public";
 
 
@@ -63,20 +74,45 @@ public class RegistrationRequest {
     public final AuthorizationServiceConfiguration configuration;
 
     /**
-     * The client's redirect URI.
+     * The client's redirect URI's.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.2"> "The OAuth 2.0
+     * Authorization
+     * Framework" (RFC 6749), Section 3.1.2</a>
      */
     @NonNull
     public final List<Uri> redirectUris;
 
+    /**
+     * The application type to register, will always be 'native'.
+     */
     @NonNull
     public final String applicationType;
 
+    /**
+     * The response types to use.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#Authentication">
+     * "OpenID Connect Core 1.0", Section 3</a>
+     */
     @Nullable
     public final List<String> responseTypes;
 
+    /**
+     * The grant types to use.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata">
+     * "OpenID Connect Dynamic Client Registration 1.0", Section 2</a>
+     */
     @Nullable
     public final List<String> grantTypes;
 
+    /**
+     * The subject type to use.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes">
+     * "OpenID Connect Core 1.0", Section 8</a>
+     */
     @Nullable
     public final String subjectType;
 
@@ -129,11 +165,23 @@ public class RegistrationRequest {
             return this;
         }
 
+        /**
+         * Specifies the redirect URI's.
+         *
+         * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.2"> "The OAuth 2.0
+         * Authorization Framework" (RFC 6749), Section 3.1.2</a>
+         */
         @NonNull
         public Builder setRedirectUriValues(@NonNull Uri... redirectUriValues) {
             return setRedirectUriValues(Arrays.asList(redirectUriValues));
         }
 
+        /**
+         * Specifies the redirect URI's.
+         *
+         * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.2"> "The OAuth 2.0
+         * Authorization Framework" (RFC 6749), Section 3.1.2</a>
+         */
         @NonNull
         public Builder setRedirectUriValues(@NonNull List<Uri> redirectUriValues) {
             checkCollectionNotEmpty(redirectUriValues, "redirectUriValues cannot be null");
@@ -141,28 +189,58 @@ public class RegistrationRequest {
             return this;
         }
 
+        /**
+         * Specifies the response types.
+         *
+         * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#Authentication">
+         * "OpenID Connect Core 1.0", Section 3</a>
+         */
         @NonNull
         public Builder setResponseTypeValues(@Nullable String... responseTypeValues) {
             return setResponseTypeValues(Arrays.asList(responseTypeValues));
         }
 
+        /**
+         * Specifies the response types.
+         *
+         * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#Authentication">
+         * "OpenID Connect Core 1.0", Section 3</a>
+         */
         @NonNull
         public Builder setResponseTypeValues(@Nullable List<String> responseTypeValues) {
             mResponseTypes = responseTypeValues;
             return this;
         }
 
+        /**
+         * Specifies the grant types.
+         *
+         * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata">
+          * "OpenID Connect Dynamic Client Registration 1.0", Section 2</a>
+         */
         @NonNull
         public Builder setGrantTypeValues(@Nullable String... grantTypeValues) {
             return setGrantTypeValues(Arrays.asList(grantTypeValues));
         }
 
+        /**
+         * Specifies the grant types.
+         *
+         * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata">
+         * "OpenID Connect Dynamic Client Registration 1.0", Section 2</a>
+         */
         @NonNull
         public Builder setGrantTypeValues(@Nullable List<String> grantTypeValues) {
             mGrantTypes = grantTypeValues;
             return this;
         }
 
+        /**
+         * Specifies the subject types.
+         *
+         * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes">
+          * "OpenID Connect Core 1.0", Section 8</a>l
+         */
         @NonNull
         public Builder setSubjectType(@Nullable String subjectType) {
             mSubjectType = subjectType;
@@ -179,12 +257,19 @@ public class RegistrationRequest {
             return this;
         }
 
+        /**
+         * Constructs the registration request. At a minimum the following fields must have been
+         * set:
+         * <ul> <li>The redirect URI's</li>
+         * </ul> Failure to specify any of these parameters will result in a runtime exception.
+         */
         @NonNull
         public RegistrationRequest build() {
             return new RegistrationRequest(
                     mConfiguration,
                     Collections.unmodifiableList(mRedirectUris),
-                    mResponseTypes == null ? mResponseTypes : Collections.unmodifiableList(mResponseTypes),
+                    mResponseTypes == null
+                            ? mResponseTypes : Collections.unmodifiableList(mResponseTypes),
                     mGrantTypes == null ? mGrantTypes : Collections.unmodifiableList(mGrantTypes),
                     mSubjectType,
                     Collections.unmodifiableMap(mAdditionalParameters));
@@ -220,6 +305,10 @@ public class RegistrationRequest {
         return json.toString();
     }
 
+    /**
+     * Converts the registration request to JSON for internal storage or transmission, e.g. between
+     * activities in intents.
+     */
     @NonNull
     public JSONObject serialize() {
         JSONObject json = serializeParams();
@@ -244,11 +333,23 @@ public class RegistrationRequest {
         return json;
     }
 
+    /**
+     * Reads a registration request from a JSON representation produced by the
+     * {@link #serialize()} method or some other equivalent producer.
+     *
+     * @throws JSONException if the provided JSON does not match the expected structure.
+     */
     public static RegistrationRequest deserialize(@NonNull String jsonStr) throws JSONException {
         checkNotEmpty(jsonStr, "jsonStr must not be empty or null");
         return deserialize(new JSONObject(jsonStr));
     }
 
+    /**
+     * Reads a registration request from a JSON representation produced by the
+     * {@link #serialize()} method or some other equivalent producer.
+     *
+     * @throws JSONException if the provided JSON does not match the expected structure.
+     */
     public static RegistrationRequest deserialize(@NonNull JSONObject json) throws JSONException {
         checkNotNull(json, "json must not be null");
         List<Uri> redirectUris = JsonUtil.getUriList(json, PARAM_REDIRECT_URIS);

--- a/library/java/net/openid/appauth/RegistrationRequest.java
+++ b/library/java/net/openid/appauth/RegistrationRequest.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 public class RegistrationRequest {
     /**
-     * OpenID Conenct 'application_type'.
+     * OpenID Connect 'application_type'.
      */
     public static final String APPLICATION_TYPE_NATIVE = "native";
 

--- a/library/java/net/openid/appauth/RegistrationRequest.java
+++ b/library/java/net/openid/appauth/RegistrationRequest.java
@@ -1,0 +1,235 @@
+package net.openid.appauth;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static net.openid.appauth.AdditionalParamsProcessor.builtInParams;
+import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;
+import static net.openid.appauth.Preconditions.checkNotNull;
+
+public class RegistrationRequest {
+    /**
+     * OpenID Conenct 'application_type'.
+     */
+    public static final String APPLICATION_TYPE_NATIVE = "native";
+
+    static final String PARAM_REDIRECT_URIS = "redirect_uris";
+    static final String PARAM_RESPONSE_TYPES = "response_types";
+    static final String PARAM_GRANT_TYPES = "grant_types";
+    static final String PARAM_APPLICATION_TYPE = "application_type";
+    static final String PARAM_SUBJECT_TYPE = "subject_type";
+
+    private static final Set<String> BUILT_IN_PARAMS = builtInParams(
+            PARAM_REDIRECT_URIS,
+            PARAM_RESPONSE_TYPES,
+            PARAM_GRANT_TYPES,
+            PARAM_APPLICATION_TYPE,
+            PARAM_SUBJECT_TYPE
+    );
+    public static final String SUBJECT_TYPE_PAIRWISE = "pairwise";
+    public static final String SUBJECT_TYPE_PUBLIC = "public";
+
+
+    /**
+     * The service's {@link AuthorizationServiceConfiguration configuration}.
+     * This configuration specifies how to connect to a particular OAuth provider.
+     * Configurations may be
+     * {@link AuthorizationServiceConfiguration#AuthorizationServiceConfiguration(Uri,
+     * Uri, Uri) created manually}, or
+     * {@link AuthorizationServiceConfiguration#fetchFromUrl(Uri,
+     * AuthorizationServiceConfiguration.RetrieveConfigurationCallback)
+     * via an OpenID Connect Discovery Document}.
+     */
+    @NonNull
+    public final AuthorizationServiceConfiguration configuration;
+
+    /**
+     * The client's redirect URI.
+     */
+    @NonNull
+    public final List<Uri> redirectUris;
+
+    @NonNull
+    public final String applicationType;
+
+    @Nullable
+    public final List<String> responseTypes;
+
+    @Nullable
+    public final List<String> grantTypes;
+
+    @Nullable
+    public final String subjectType;
+
+    /**
+     * Additional parameters to be passed as part of the request.
+     */
+    @NonNull
+    public final Map<String, String> additionalParameters;
+
+
+    /**
+     * Creates instances of {@link RegistrationRequest}.
+     */
+    public static final class Builder {
+        @NonNull
+        private AuthorizationServiceConfiguration mConfiguration;
+        @NonNull
+        private List<Uri> mRedirectUris = new ArrayList<>();
+
+        @Nullable
+        private List<String> mResponseTypes;
+
+        @Nullable
+        private List<String> mGrantTypes;
+
+        @Nullable
+        private String mSubjectType;
+
+        @NonNull
+        private Map<String, String> mAdditionalParameters = Collections.emptyMap();
+
+
+        /**
+         * Creates a registration request builder with the specified mandatory properties.
+         */
+        public Builder(
+                @NonNull AuthorizationServiceConfiguration configuration,
+                @NonNull Uri redirectUri) {
+            setConfiguration(configuration);
+            setRedirectUri(redirectUri);
+        }
+
+        /**
+         * Specifies the authorization service configuration for the request, which must not
+         * be null or empty.
+         */
+        @NonNull
+        public Builder setConfiguration(@NonNull AuthorizationServiceConfiguration configuration) {
+            mConfiguration = checkNotNull(configuration);
+            return this;
+        }
+
+        /**
+         * Specifies the client's redirect URI. Cannot be null or empty.
+         */
+        @NonNull
+        public Builder setRedirectUri(@NonNull Uri redirectUri) {
+            return setRedirectUriValues(checkNotNull(redirectUri, "redirect URI cannot be null or empty"));
+        }
+
+        @NonNull
+        public Builder setRedirectUriValues(@Nullable Uri... redirectUriValues) {
+            return setRedirectUriValues(Arrays.asList(redirectUriValues));
+        }
+
+        @NonNull
+        public Builder setRedirectUriValues(@Nullable List<Uri> redirectUriValues) {
+            mRedirectUris.clear();
+            if (redirectUriValues != null) {
+                mRedirectUris.addAll(redirectUriValues);
+            }
+            return this;
+        }
+
+        @NonNull
+        public Builder setResponseTypeValues(@Nullable String... responseTypeValues) {
+            return setResponseTypeValues(Arrays.asList(responseTypeValues));
+        }
+
+        @NonNull
+        public Builder setResponseTypeValues(@Nullable List<String> responseTypeValues) {
+            mResponseTypes = responseTypeValues;
+            return this;
+        }
+
+        @NonNull
+        public Builder setGrantTypeValues(@Nullable String... grantTypeValues) {
+            return setGrantTypeValues(Arrays.asList(grantTypeValues));
+        }
+
+        @NonNull
+        public Builder setGrantTypeValues(@Nullable List<String> grantTypeValues) {
+            mGrantTypes = grantTypeValues;
+            return this;
+        }
+
+        @NonNull
+        public Builder setSubjectType(@Nullable String subjectType) {
+            mSubjectType = subjectType;
+            return this;
+        }
+
+        /**
+         * Specifies additional parameters. Replaces any previously provided set of parameters.
+         * Parameter keys and values cannot be null or empty.
+         */
+        @NonNull
+        public Builder setAdditionalParameters(@Nullable Map<String, String> additionalParameters) {
+            mAdditionalParameters = checkAdditionalParams(additionalParameters, BUILT_IN_PARAMS);
+            return this;
+        }
+
+        @NonNull
+        public RegistrationRequest build() {
+            return new RegistrationRequest(
+                    mConfiguration,
+                    Collections.unmodifiableList(mRedirectUris),
+                    mResponseTypes == null ? mResponseTypes : Collections.unmodifiableList(mResponseTypes),
+                    mGrantTypes == null ? mGrantTypes : Collections.unmodifiableList(mGrantTypes),
+                    mSubjectType,
+                    Collections.unmodifiableMap(mAdditionalParameters));
+        }
+    }
+
+    private RegistrationRequest(
+            @NonNull AuthorizationServiceConfiguration configuration,
+            @NonNull List<Uri> redirectUris,
+            @Nullable List<String> responseTypes,
+            @Nullable List<String> grantTypes,
+            @Nullable String subjectType,
+            @NonNull Map<String, String> additionalParameters) {
+        this.configuration = configuration;
+        this.redirectUris = redirectUris;
+        this.responseTypes = responseTypes;
+        this.grantTypes = grantTypes;
+        this.subjectType = subjectType;
+        this.additionalParameters = additionalParameters;
+        this.applicationType = APPLICATION_TYPE_NATIVE;
+    }
+
+
+    /**
+     * Converts the registration request to JSON for transmission.
+     */
+    @NonNull
+    public String toJsonString() {
+        JSONObject json = new JSONObject();
+        JsonUtil.put(json, PARAM_REDIRECT_URIS, JsonUtil.toJsonArray(redirectUris));
+        JsonUtil.put(json, PARAM_APPLICATION_TYPE, applicationType);
+
+        if (responseTypes != null) {
+            JsonUtil.put(json, PARAM_RESPONSE_TYPES, JsonUtil.toJsonArray(responseTypes));
+        }
+        if (grantTypes != null) {
+            JsonUtil.put(json, PARAM_GRANT_TYPES, JsonUtil.toJsonArray(grantTypes));
+        }
+        JsonUtil.putIfNotNull(json, PARAM_SUBJECT_TYPE, subjectType);
+
+        for (Map.Entry<String, String> param : additionalParameters.entrySet()) {
+            JsonUtil.put(json, param.getKey(), param.getValue());
+        }
+
+        return json.toString();
+    }
+}

--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -1,0 +1,290 @@
+package net.openid.appauth;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+import android.text.TextUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;
+import static net.openid.appauth.AdditionalParamsProcessor.extractAdditionalParams;
+import static net.openid.appauth.Preconditions.checkArgument;
+import static net.openid.appauth.Preconditions.checkNotEmpty;
+import static net.openid.appauth.Preconditions.checkNotNull;
+
+public class RegistrationResponse {
+    static final String PARAM_CLIENT_ID = "client_id";
+    static final String PARAM_CLIENT_SECRET = "client_secret";
+    static final String PARAM_CLIENT_SECRET_EXPIRES_AT = "client_secret_expires_at";
+    static final String PARAM_REGISTRATION_ACCESS_TOKEN = "registration_access_token";
+    static final String PARAM_REGISTRATION_CLIENT_URI = "registration_client_uri";
+    static final String PARAM_CLIENT_ID_ISSUED_AT = "client_id_issued_at";
+
+    private static final Set<String> BUILT_IN_PARAMS = new HashSet<>(Arrays.asList(
+            PARAM_CLIENT_ID,
+            PARAM_CLIENT_SECRET,
+            PARAM_CLIENT_SECRET_EXPIRES_AT,
+            PARAM_REGISTRATION_ACCESS_TOKEN,
+            PARAM_REGISTRATION_CLIENT_URI,
+            PARAM_CLIENT_ID_ISSUED_AT
+    ));
+    /**
+     * The registration request associated with this response.
+     */
+    @NonNull
+    public final RegistrationRequest request;
+    @NonNull
+    public final String clientId;
+    @Nullable
+    public final Long clientIdIssuedAt;
+    @Nullable
+    public final String clientSecret;
+    @Nullable
+    public final Long clientSecretExpiresAt;
+    @Nullable
+    public final String registrationAccessToken;
+    @Nullable
+    public final Uri registrationClientUri;
+
+    /**
+     * Additional, non-standard parameters in the response.
+     */
+    @NonNull
+    public final Map<String, String> additionalParameters;
+
+    /**
+     * Thrown when a mandatory property is missing from the registration response.
+     */
+    public static class MissingArgumentException extends Exception {
+        private String mMissingField;
+
+        /**
+         * Indicates that the specified mandatory field is missing from the registration response.
+         */
+        public MissingArgumentException(String field) {
+            super("Missing mandatory registration field: " + field);
+            mMissingField = field;
+        }
+
+        public String getMissingField() {
+            return mMissingField;
+        }
+    }
+
+    public static final class Builder {
+        @NonNull
+        private RegistrationRequest mRequest;
+        @NonNull
+        private String mClientId;
+
+        @Nullable
+        private Long mClientIdIssuedAt;
+        @Nullable
+        private String mClientSecret;
+        @Nullable
+        private Long mClientSecretExpiresAt;
+        @Nullable
+        private String mRegistrationAccessToken;
+        @Nullable
+        private Uri mRegistrationClientUri;
+
+        @NonNull
+        private Map<String, String> mAdditionalParameters = Collections.emptyMap();
+
+        /**
+         * Creates a token response associated with the specified request.
+         */
+        public Builder(@NonNull RegistrationRequest request) {
+            setRequest(request);
+        }
+
+        /**
+         * Specifies the request associated with this response. Must not be null.
+         */
+        @NonNull
+        public Builder setRequest(@NonNull RegistrationRequest request) {
+            mRequest = checkNotNull(request, "request cannot be null");
+            return this;
+        }
+
+
+        public Builder setClientId(@NonNull String clientId) {
+            checkArgument(!TextUtils.isEmpty(clientId), "client ID cannot be null or empty");
+            mClientId = clientId;
+            return this;
+        }
+
+        public Builder setClientIdIssuedAt(@Nullable Long clientIdIssuedAt) {
+            mClientIdIssuedAt = clientIdIssuedAt;
+            return this;
+        }
+
+        public Builder setClientSecret(@Nullable String clientSecret) {
+            mClientSecret = clientSecret;
+            return this;
+        }
+
+        public Builder setClientSecretExpiresAt(@Nullable Long clientSecretExpiresAt) {
+            mClientSecretExpiresAt = clientSecretExpiresAt;
+            return this;
+        }
+
+        public Builder setRegistrationAccessToken(@Nullable String registrationAccessToken) {
+            mRegistrationAccessToken = registrationAccessToken;
+            return this;
+        }
+
+        public Builder setRegistrationClientUri(@Nullable Uri registrationClientUri) {
+            mRegistrationClientUri = registrationClientUri;
+            return this;
+        }
+
+        public Builder setAdditionalParameters(Map<String, String> additionalParameters) {
+            mAdditionalParameters = checkAdditionalParams(additionalParameters, BUILT_IN_PARAMS);
+            return this;
+        }
+
+        /**
+         * Creates the token response instance.
+         */
+        public RegistrationResponse build() {
+            return new RegistrationResponse(
+                    mRequest,
+                    mClientId,
+                    mClientIdIssuedAt,
+                    mClientSecret,
+                    mClientSecretExpiresAt,
+                    mRegistrationAccessToken,
+                    mRegistrationClientUri,
+                    mAdditionalParameters);
+        }
+
+        /**
+         * Extracts registration response fields from a JSON string.
+         *
+         * @throws JSONException if the JSON is malformed or has incorrect value types for fields.
+         */
+        @NonNull
+        public Builder fromResponseJsonString(@NonNull String jsonStr) throws JSONException, MissingArgumentException {
+            checkNotEmpty(jsonStr, "json cannot be null or empty");
+            return fromResponseJson(new JSONObject(jsonStr));
+        }
+
+        /**
+         * Extracts token response fields from a JSON object.
+         *
+         * @throws JSONException if the JSON is malformed or has incorrect value types for fields.
+         */
+        @NonNull
+        public Builder fromResponseJson(@NonNull JSONObject json) throws JSONException,
+                MissingArgumentException {
+            setClientId(JsonUtil.getString(json, PARAM_CLIENT_ID));
+            setClientIdIssuedAt(JsonUtil.getLongIfDefined(json, PARAM_CLIENT_ID_ISSUED_AT));
+
+            if (json.has(PARAM_CLIENT_SECRET)) {
+                if (!json.has(PARAM_CLIENT_SECRET_EXPIRES_AT)) {
+                    /*
+                     * From OpenID Connect Dynamic Client Registration, Section 3.2:
+                     * client_secret_expires_at: "REQUIRED if client_secret is issued"
+                     */
+                    throw new MissingArgumentException(PARAM_CLIENT_SECRET_EXPIRES_AT);
+                }
+                setClientSecret(json.getString(PARAM_CLIENT_SECRET));
+                setClientSecretExpiresAt(json.getLong(PARAM_CLIENT_SECRET_EXPIRES_AT));
+            }
+
+            if (json.has(PARAM_REGISTRATION_ACCESS_TOKEN) != json.has(PARAM_REGISTRATION_CLIENT_URI)) {
+                /*
+                 * From OpenID Connect Dynamic Client Registration, Section 3.2:
+                 * "Implementations MUST either return both a Client Configuration Endpoint and a
+                 * Registration Access Token or neither of them."
+                 */
+                String missingParameter = json.has(PARAM_REGISTRATION_ACCESS_TOKEN)
+                        ? PARAM_REGISTRATION_CLIENT_URI : PARAM_REGISTRATION_ACCESS_TOKEN;
+                throw new MissingArgumentException(missingParameter);
+            }
+
+            setRegistrationAccessToken(JsonUtil.getStringIfDefined(json,
+                    PARAM_REGISTRATION_ACCESS_TOKEN));
+            if (json.has(PARAM_REGISTRATION_CLIENT_URI)) {
+                setRegistrationClientUri(Uri.parse(json.getString(PARAM_REGISTRATION_CLIENT_URI)));
+            }
+
+            setAdditionalParameters(extractAdditionalParams(json, BUILT_IN_PARAMS));
+            return this;
+        }
+    }
+
+    private RegistrationResponse(
+            @NonNull RegistrationRequest request,
+            @NonNull String clientId,
+            @Nullable Long clientIdIssuedAt,
+            @Nullable String clientSecret,
+            @Nullable Long clientSecretExpiresAt,
+            @Nullable String registrationAccessToken,
+            @Nullable Uri registrationClientUri,
+            @NonNull Map<String, String> additionalParameters) {
+        this.request = request;
+        this.clientId = clientId;
+        this.clientIdIssuedAt = clientIdIssuedAt;
+        this.clientSecret = clientSecret;
+        this.clientSecretExpiresAt = clientSecretExpiresAt;
+        this.registrationAccessToken = registrationAccessToken;
+        this.registrationClientUri = registrationClientUri;
+        this.additionalParameters = additionalParameters;
+    }
+
+    /**
+     * Reads a registration response from a JSON string, and associates it with the provided request.
+     *
+     * @throws JSONException if the JSON is malformed or missing required fields.
+     */
+    @NonNull
+    public static RegistrationResponse fromJson(
+            @NonNull RegistrationRequest request,
+            @NonNull String jsonStr)
+            throws JSONException, MissingArgumentException {
+        checkNotEmpty(jsonStr, "jsonStr cannot be null or empty");
+        return fromJson(request, new JSONObject(jsonStr));
+    }
+
+    /**
+     * Reads a registration response from a JSON object, and associates it with the provided request.
+     *
+     * @throws JSONException if the JSON is malformed or missing required fields.
+     */
+    @NonNull
+    public static RegistrationResponse fromJson(
+            @NonNull RegistrationRequest request,
+            @NonNull JSONObject json)
+            throws JSONException, MissingArgumentException {
+        checkNotNull(request, "registration request cannot be null");
+        return new RegistrationResponse.Builder(request)
+                .fromResponseJson(json)
+                .build();
+    }
+
+    /**
+     * Determines whether the returned access token has expired.
+     */
+    public boolean hasClientSecretExpired() {
+        return hasClientSecretExpired(SystemClock.INSTANCE);
+    }
+
+    @VisibleForTesting
+    boolean hasClientSecretExpired(@NonNull Clock clock) {
+        Long now = TimeUnit.MILLISECONDS.toSeconds(checkNotNull(clock).getCurrentTimeMillis());
+        return clientSecretExpiresAt != null && now > clientSecretExpiresAt;
+
+    }
+}

--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -177,7 +177,7 @@ public class RegistrationResponse {
          * Framework" (RFC 6749), Section 4.1.1</a>
          */
         public Builder setClientId(@NonNull String clientId) {
-            checkArgument(!TextUtils.isEmpty(clientId), "client ID cannot be null or empty");
+            checkNotEmpty(clientId, "client ID cannot be null or empty");
             mClientId = clientId;
             return this;
         }
@@ -314,7 +314,8 @@ public class RegistrationResponse {
             setRegistrationAccessToken(JsonUtil.getStringIfDefined(json,
                     PARAM_REGISTRATION_ACCESS_TOKEN));
             if (json.has(PARAM_REGISTRATION_CLIENT_URI)) {
-                setRegistrationClientUri(Uri.parse(json.getString(PARAM_REGISTRATION_CLIENT_URI)));
+                setRegistrationClientUri(JsonUtil.getUriIfDefined(json,
+                        PARAM_REGISTRATION_CLIENT_URI));
             }
 
             setAdditionalParameters(extractAdditionalParams(json, BUILT_IN_PARAMS));

--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -2,7 +2,6 @@ package net.openid.appauth;
 
 import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;
 import static net.openid.appauth.AdditionalParamsProcessor.extractAdditionalParams;
-import static net.openid.appauth.Preconditions.checkArgument;
 import static net.openid.appauth.Preconditions.checkNotEmpty;
 import static net.openid.appauth.Preconditions.checkNotNull;
 
@@ -10,7 +9,6 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.text.TextUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -313,10 +311,7 @@ public class RegistrationResponse {
 
             setRegistrationAccessToken(JsonUtil.getStringIfDefined(json,
                     PARAM_REGISTRATION_ACCESS_TOKEN));
-            if (json.has(PARAM_REGISTRATION_CLIENT_URI)) {
-                setRegistrationClientUri(JsonUtil.getUriIfDefined(json,
-                        PARAM_REGISTRATION_CLIENT_URI));
-            }
+            setRegistrationClientUri(JsonUtil.getUriIfDefined(json, PARAM_REGISTRATION_CLIENT_URI));
 
             setAdditionalParameters(extractAdditionalParams(json, BUILT_IN_PARAMS));
             return this;

--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openid.appauth;
 
 import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;

--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -1,5 +1,11 @@
 package net.openid.appauth;
 
+import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;
+import static net.openid.appauth.AdditionalParamsProcessor.extractAdditionalParams;
+import static net.openid.appauth.Preconditions.checkArgument;
+import static net.openid.appauth.Preconditions.checkNotEmpty;
+import static net.openid.appauth.Preconditions.checkNotNull;
+
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -15,12 +21,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static net.openid.appauth.AdditionalParamsProcessor.checkAdditionalParams;
-import static net.openid.appauth.AdditionalParamsProcessor.extractAdditionalParams;
-import static net.openid.appauth.Preconditions.checkArgument;
-import static net.openid.appauth.Preconditions.checkNotEmpty;
-import static net.openid.appauth.Preconditions.checkNotNull;
 
 public class RegistrationResponse {
     static final String PARAM_CLIENT_ID = "client_id";
@@ -46,16 +46,62 @@ public class RegistrationResponse {
      */
     @NonNull
     public final RegistrationRequest request;
+
+    /**
+     * The registered client identifier.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4"> "The OAuth 2.0 Authorization
+     * Framework" (RFC 6749), Section 4</a>
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.1"> "The OAuth 2.0
+     * Authorization
+     * Framework" (RFC 6749), Section 4.1.1</a>
+     */
     @NonNull
     public final String clientId;
+
+    /**
+     * Timestamp of when the client identifier was issued, if provided.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+     * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+     */
     @Nullable
     public final Long clientIdIssuedAt;
+
+    /**
+     * The client secret, which is part of the client credentials, if provided.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+     * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+     */
     @Nullable
     public final String clientSecret;
+
+    /**
+     * Timestamp of when the client credentials expires, if provided.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+     * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+     */
     @Nullable
     public final Long clientSecretExpiresAt;
+
+    /**
+     * Client registration access token that can be used for subsequent operations upon the client
+     * registration.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+     * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+     */
     @Nullable
     public final String registrationAccessToken;
+
+    /**
+     * Location of the client configuration endpoint, if provided.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+     * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+     */
     @Nullable
     public final Uri registrationClientUri;
 
@@ -121,38 +167,79 @@ public class RegistrationResponse {
             return this;
         }
 
-
+        /**
+         * Specifies the client identifier.
+         *
+         * @see <a href="https://tools.ietf.org/html/rfc6749#section-4"> "The OAuth 2.0 Authorization
+         * Framework" (RFC 6749), Section 4</a>
+         * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.1"> "The OAuth 2.0
+         * Authorization
+         * Framework" (RFC 6749), Section 4.1.1</a>
+         */
         public Builder setClientId(@NonNull String clientId) {
             checkArgument(!TextUtils.isEmpty(clientId), "client ID cannot be null or empty");
             mClientId = clientId;
             return this;
         }
 
+        /**
+         * Specifies the timestamp for when the client identifier was issued.
+         *
+         * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+         * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+         */
         public Builder setClientIdIssuedAt(@Nullable Long clientIdIssuedAt) {
             mClientIdIssuedAt = clientIdIssuedAt;
             return this;
         }
 
+        /**
+         * Specifies the client secret.
+         *
+         * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+         * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+         */
         public Builder setClientSecret(@Nullable String clientSecret) {
             mClientSecret = clientSecret;
             return this;
         }
 
+        /**
+         * Specifies the expiration time of the client secret.
+         *
+         * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+         * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+         */
         public Builder setClientSecretExpiresAt(@Nullable Long clientSecretExpiresAt) {
             mClientSecretExpiresAt = clientSecretExpiresAt;
             return this;
         }
 
+        /**
+         * Specifies the registration access token.
+         *
+         * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+         * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+         */
         public Builder setRegistrationAccessToken(@Nullable String registrationAccessToken) {
             mRegistrationAccessToken = registrationAccessToken;
             return this;
         }
 
+        /**
+         * Specifies the client configuration endpoint.
+         *
+         * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
+         * "OpenID Connect Dynamic Client Registration 1.0", Section 3.2</a>
+         */
         public Builder setRegistrationClientUri(@Nullable Uri registrationClientUri) {
             mRegistrationClientUri = registrationClientUri;
             return this;
         }
 
+        /**
+         * Specifies the additional, non-standard parameters received as part of the response.
+         */
         public Builder setAdditionalParameters(Map<String, String> additionalParameters) {
             mAdditionalParameters = checkAdditionalParams(additionalParameters, BUILT_IN_PARAMS);
             return this;
@@ -177,9 +264,12 @@ public class RegistrationResponse {
          * Extracts registration response fields from a JSON string.
          *
          * @throws JSONException if the JSON is malformed or has incorrect value types for fields.
+         * @throws MissingArgumentException if the JSON is missing fields required by the
+         *                                  specification.
          */
         @NonNull
-        public Builder fromResponseJsonString(@NonNull String jsonStr) throws JSONException, MissingArgumentException {
+        public Builder fromResponseJsonString(@NonNull String jsonStr)
+                throws JSONException, MissingArgumentException {
             checkNotEmpty(jsonStr, "json cannot be null or empty");
             return fromResponseJson(new JSONObject(jsonStr));
         }
@@ -188,10 +278,12 @@ public class RegistrationResponse {
          * Extracts token response fields from a JSON object.
          *
          * @throws JSONException if the JSON is malformed or has incorrect value types for fields.
+         * @throws MissingArgumentException if the JSON is missing fields required by the
+         *                                  specification.
          */
         @NonNull
-        public Builder fromResponseJson(@NonNull JSONObject json) throws JSONException,
-                MissingArgumentException {
+        public Builder fromResponseJson(@NonNull JSONObject json)
+                throws JSONException, MissingArgumentException {
             setClientId(JsonUtil.getString(json, PARAM_CLIENT_ID));
             setClientIdIssuedAt(JsonUtil.getLongIfDefined(json, PARAM_CLIENT_ID_ISSUED_AT));
 
@@ -207,7 +299,8 @@ public class RegistrationResponse {
                 setClientSecretExpiresAt(json.getLong(PARAM_CLIENT_SECRET_EXPIRES_AT));
             }
 
-            if (json.has(PARAM_REGISTRATION_ACCESS_TOKEN) != json.has(PARAM_REGISTRATION_CLIENT_URI)) {
+            if (json.has(PARAM_REGISTRATION_ACCESS_TOKEN)
+                    != json.has(PARAM_REGISTRATION_CLIENT_URI)) {
                 /*
                  * From OpenID Connect Dynamic Client Registration, Section 3.2:
                  * "Implementations MUST either return both a Client Configuration Endpoint and a
@@ -249,23 +342,28 @@ public class RegistrationResponse {
     }
 
     /**
-     * Reads a registration response from a JSON string, and associates it with the provided request.
+     * Reads a registration response from a JSON string, and associates it with the provided
+     * request.
      *
-     * @throws JSONException if the JSON is malformed or missing required fields.
+     * @throws JSONException            if the JSON is malformed or missing required fields.
+     * @throws MissingArgumentException if the JSON is missing fields required by the
+     *                                  specification.
      */
     @NonNull
     public static RegistrationResponse fromJson(
-            @NonNull RegistrationRequest request,
-            @NonNull String jsonStr)
+            @NonNull RegistrationRequest request, @NonNull String jsonStr)
             throws JSONException, MissingArgumentException {
         checkNotEmpty(jsonStr, "jsonStr cannot be null or empty");
         return fromJson(request, new JSONObject(jsonStr));
     }
 
     /**
-     * Reads a registration response from a JSON object, and associates it with the provided request.
+     * Reads a registration response from a JSON object, and associates it with the provided
+     * request.
      *
-     * @throws JSONException if the JSON is malformed or missing required fields.
+     * @throws JSONException            if the JSON is malformed or missing required fields.
+     * @throws MissingArgumentException if the JSON is missing fields required by the
+     *                                  specification.
      */
     @NonNull
     public static RegistrationResponse fromJson(
@@ -297,9 +395,12 @@ public class RegistrationResponse {
     }
 
     /**
-     * Reads a registration response from a JSON string, and associates it with the provided request.
+     * Reads a registration response from a JSON string, and associates it with the provided
+     * request.
      *
      * @throws JSONException if the JSON is malformed or missing required fields.
+     * @throws MissingArgumentException if the JSON is missing fields required by the
+     *                                  specification.
      */
     @NonNull
     public static RegistrationResponse deserialize(@NonNull String jsonStr)
@@ -308,12 +409,20 @@ public class RegistrationResponse {
         return deserialize(new JSONObject(jsonStr));
     }
 
-    public static RegistrationResponse deserialize(@NonNull JSONObject json) throws JSONException, MissingArgumentException {
+    /**
+     *
+     * @throws JSONException if the JSON is malformed or missing required fields.
+     * @throws MissingArgumentException if the JSON is missing fields required by the
+     *                                  specification.
+     */
+    public static RegistrationResponse deserialize(@NonNull JSONObject json) throws JSONException,
+            MissingArgumentException {
         checkNotNull(json, "json cannot be null");
         if (!json.has(KEY_REQUEST)) {
             throw new IllegalArgumentException("registration request not found in JSON");
         }
-        RegistrationRequest request = RegistrationRequest.deserialize(json.getJSONObject(KEY_REQUEST));
+        RegistrationRequest request = RegistrationRequest.deserialize(
+                json.getJSONObject(KEY_REQUEST));
 
         return new RegistrationResponse.Builder(request)
                 .fromResponseJson(json)

--- a/library/java/net/openid/appauth/ResponseTypeValues.java
+++ b/library/java/net/openid/appauth/ResponseTypeValues.java
@@ -1,5 +1,12 @@
 package net.openid.appauth;
 
+/**
+ * The response type values defined by the <a href="https://tools.ietf.org/html/rfc6749">"The OAuth
+ * 2.0 Authorization Framework" (RFC 6749)</a> and
+ * <a href="http://openid.net/specs/openid-connect-core-1_0.html">"OpenID Connect Core 1.0</a>
+ * specifications, used in {@link AuthorizationRequest authorization} and
+ * {@link RegistrationRequest dynamic client registration} requests.
+ */
 public class ResponseTypeValues {
     /**
      * For requesting an authorization code.
@@ -21,7 +28,7 @@ public class ResponseTypeValues {
      * For requesting an OpenID Conenct ID Token.
      *
      * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#IDToken">
-     *     "OpenID Connect Core 1.0", Section 2</a>
+     * "OpenID Connect Core 1.0", Section 2</a>
      */
     public static final String ID_TOKEN = "id_token";
 

--- a/library/java/net/openid/appauth/ResponseTypeValues.java
+++ b/library/java/net/openid/appauth/ResponseTypeValues.java
@@ -1,0 +1,28 @@
+package net.openid.appauth;
+
+public class ResponseTypeValues {
+    /**
+     * For requesting an authorization code.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.1"> "The OAuth 2.0
+     * Authorization Framework" (RFC 6749), Section 3.1.1</a>
+     */
+    public static final String CODE = "code";
+
+    /**
+     * For requesting an access token via an implicit grant.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.1"> "The OAuth 2.0
+     * Authorization Framework" (RFC 6749), Section 3.1.1</a>
+     */
+    public static final String TOKEN = "token";
+
+    /**
+     * For requesting an OpenID Conenct ID Token.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#IDToken">
+     *     "OpenID Connect Core 1.0", Section 2</a>
+     */
+    public static final String ID_TOKEN = "id_token";
+
+}

--- a/library/java/net/openid/appauth/ResponseTypeValues.java
+++ b/library/java/net/openid/appauth/ResponseTypeValues.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openid.appauth;
 
 /**

--- a/library/java/net/openid/appauth/TokenRequest.java
+++ b/library/java/net/openid/appauth/TokenRequest.java
@@ -95,25 +95,11 @@ public class TokenRequest {
                     PARAM_REFRESH_TOKEN,
                     PARAM_SCOPE)));
 
-    /**
-     * The grant type used for exchanging an authorization code for one or more tokens.
-     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.3"> "The OAuth 2.0
-     * Authorization
-     * Framework" (RFC 6749), Section 4.1.3</a>
-     */
-    public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
-
-    /**
-     * The grant type used when exchanging a refresh token for a new token.
-     * @see <a href="https://tools.ietf.org/html/rfc6749#section-6"> "The OAuth 2.0
-     * Authorization
-     * Framework" (RFC 6749), Section 6</a>
-     */
-    public static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
 
     /**
      * The grant type used when requesting an access token using a username and password.
      * This grant type is not directly supported by this library.
+     *
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.3.2"> "The OAuth 2.0
      * Authorization Framework" (RFC 6749), Section 4.3.2</a>
      */
@@ -122,6 +108,7 @@ public class TokenRequest {
     /**
      * The grant type used when requesting an access token using client credentials, typically
      * TLS client certificates. This grant type is not directly supported by this library.
+     *
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4.2"> "The OAuth 2.0
      * Authorization Framework" (RFC 6749), Section 4.4.2</a>
      */
@@ -132,7 +119,7 @@ public class TokenRequest {
      * This configuration specifies how to connect to a particular OAuth provider.
      * Configurations may be
      * {@link AuthorizationServiceConfiguration#AuthorizationServiceConfiguration(Uri,
-     * Uri) created manually}, or
+     * Uri, Uri) created manually}, or
      * {@link AuthorizationServiceConfiguration#fetchFromUrl(Uri,
      * AuthorizationServiceConfiguration.RetrieveConfigurationCallback)
      * via an OpenID Connect Discovery Document}.
@@ -328,7 +315,7 @@ public class TokenRequest {
         /**
          * Specifies the set of case-sensitive scopes. Replaces any previously specified set of
          * scopes. Individual scope strings cannot be null or empty.
-         *
+         * <p/>
          * <p>Scopes specified here are used to obtain a "down-scoped" access token, where the
          * set of scopes specified <em>must</em> be a subset of those already granted in
          * previous requests.
@@ -350,7 +337,7 @@ public class TokenRequest {
         /**
          * Specifies the set of case-sensitive scopes. Replaces any previously specified set of
          * scopes. Individual scope strings cannot be null or empty.
-         *
+         * <p/>
          * <p>Scopes specified here are used to obtain a "down-scoped" access token, where the
          * set of scopes specified <em>must</em> be a subset of those already granted in
          * previous requests.
@@ -370,7 +357,7 @@ public class TokenRequest {
         /**
          * Specifies the authorization code for the request. If provided, the authorization code
          * must not be empty.
-         *
+         * <p/>
          * <p>Specifying an authorization code normally implies that this is a request to exchange
          * this authorization code for one or more tokens. If this is not intended, the grant type
          * should be explicitly set.
@@ -385,7 +372,7 @@ public class TokenRequest {
         /**
          * Specifies the refresh token for the request. If a non-null value is provided, it must
          * not be empty.
-         *
+         * <p/>
          * <p>Specifying a refresh token normally implies that this is a request to exchange the
          * refresh token for a new token. If this is not intended, the grant type should be
          * explicit set.
@@ -429,20 +416,20 @@ public class TokenRequest {
         public TokenRequest build() {
             String grantType = inferGrantType();
 
-            if (GRANT_TYPE_AUTHORIZATION_CODE.equals(grantType)) {
+            if (GrantTypeValues.AUTHORIZATION_CODE.equals(grantType)) {
                 checkNotNull(mAuthorizationCode,
                         "authorization code must be specified for grant_type = "
-                                + GRANT_TYPE_AUTHORIZATION_CODE);
+                                + GrantTypeValues.AUTHORIZATION_CODE);
             }
 
-            if (GRANT_TYPE_REFRESH_TOKEN.equals(grantType)) {
+            if (GrantTypeValues.REFRESH_TOKEN.equals(grantType)) {
                 checkNotNull(mRefreshToken,
                         "refresh token must be specified for grant_type = "
-                                + GRANT_TYPE_REFRESH_TOKEN);
+                                + GrantTypeValues.REFRESH_TOKEN);
             }
 
 
-            if (grantType.equals(GRANT_TYPE_AUTHORIZATION_CODE) && mRedirectUri == null) {
+            if (grantType.equals(GrantTypeValues.AUTHORIZATION_CODE) && mRedirectUri == null) {
                 throw new IllegalStateException(
                         "no redirect URI specified on token request for code exchange");
             }
@@ -463,9 +450,9 @@ public class TokenRequest {
             if (mGrantType != null) {
                 return mGrantType;
             } else if (mAuthorizationCode != null) {
-                return GRANT_TYPE_AUTHORIZATION_CODE;
+                return GrantTypeValues.AUTHORIZATION_CODE;
             } else if (mRefreshToken != null) {
-                return GRANT_TYPE_REFRESH_TOKEN;
+                return GrantTypeValues.REFRESH_TOKEN;
             } else {
                 throw new IllegalStateException("grant type not specified and cannot be inferred");
             }
@@ -579,6 +566,7 @@ public class TokenRequest {
     /**
      * Reads a token request from a JSON string representation produced by the
      * {@link #toJson()} method or some other equivalent producer.
+     *
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
     @NonNull
@@ -590,6 +578,7 @@ public class TokenRequest {
     /**
      * Reads a token request from a JSON representation produced by the
      * {@link #toJson()} method or some other equivalent producer.
+     *
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
     @NonNull

--- a/library/java/net/openid/appauth/TokenRequest.java
+++ b/library/java/net/openid/appauth/TokenRequest.java
@@ -315,10 +315,10 @@ public class TokenRequest {
         /**
          * Specifies the set of case-sensitive scopes. Replaces any previously specified set of
          * scopes. Individual scope strings cannot be null or empty.
-         * <p/>
+         *
          * <p>Scopes specified here are used to obtain a "down-scoped" access token, where the
          * set of scopes specified <em>must</em> be a subset of those already granted in
-         * previous requests.
+         * previous requests.</p>
          *
          * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.3"> "The OAuth 2.0
          * Authorization Framework" (RFC 6749), Section 3.3</a>
@@ -337,10 +337,10 @@ public class TokenRequest {
         /**
          * Specifies the set of case-sensitive scopes. Replaces any previously specified set of
          * scopes. Individual scope strings cannot be null or empty.
-         * <p/>
+         *
          * <p>Scopes specified here are used to obtain a "down-scoped" access token, where the
          * set of scopes specified <em>must</em> be a subset of those already granted in
-         * previous requests.
+         * previous requests.</p>
          *
          * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.3"> "The OAuth 2.0
          * Authorization
@@ -357,10 +357,10 @@ public class TokenRequest {
         /**
          * Specifies the authorization code for the request. If provided, the authorization code
          * must not be empty.
-         * <p/>
+         *
          * <p>Specifying an authorization code normally implies that this is a request to exchange
          * this authorization code for one or more tokens. If this is not intended, the grant type
-         * should be explicitly set.
+         * should be explicitly set.</p>
          */
         @NonNull
         public Builder setAuthorizationCode(@Nullable String authorizationCode) {
@@ -372,10 +372,10 @@ public class TokenRequest {
         /**
          * Specifies the refresh token for the request. If a non-null value is provided, it must
          * not be empty.
-         * <p/>
+         *
          * <p>Specifying a refresh token normally implies that this is a request to exchange the
          * refresh token for a new token. If this is not intended, the grant type should be
-         * explicit set.
+         * explicit set.</p>
          */
         @NonNull
         public Builder setRefreshToken(@Nullable String refreshToken) {

--- a/library/javatests/net/openid/appauth/AuthStateTest.java
+++ b/library/javatests/net/openid/appauth/AuthStateTest.java
@@ -304,7 +304,7 @@ public class AuthStateTest {
         assertThat(request.configuration.tokenEndpoint)
                 .isEqualTo(state.getAuthorizationServiceConfiguration().tokenEndpoint);
         assertThat(request.clientId).isEqualTo(authResp.request.clientId);
-        assertThat(request.grantType).isEqualTo(TokenRequest.GRANT_TYPE_REFRESH_TOKEN);
+        assertThat(request.grantType).isEqualTo(GrantTypeValues.REFRESH_TOKEN);
         assertThat(request.refreshToken).isEqualTo(state.getRefreshToken());
     }
 

--- a/library/javatests/net/openid/appauth/AuthorizationRequestTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationRequestTest.java
@@ -70,13 +70,13 @@ public class AuthorizationRequestTest {
         mMinimalRequestBuilder = new AuthorizationRequest.Builder(
                 getTestServiceConfig(),
                 TEST_CLIENT_ID,
-                AuthorizationRequest.RESPONSE_TYPE_CODE,
+                ResponseTypeValues.CODE,
                 TEST_APP_REDIRECT_URI);
 
         mRequestBuilder = new AuthorizationRequest.Builder(
                 getTestServiceConfig(),
                 TEST_CLIENT_ID,
-                AuthorizationRequest.RESPONSE_TYPE_CODE,
+                ResponseTypeValues.CODE,
                 TEST_APP_REDIRECT_URI)
                 .setState(TEST_STATE)
                 .setScopes(AuthorizationRequest.SCOPE_OPENID, AuthorizationRequest.SCOPE_EMAIL)
@@ -104,7 +104,7 @@ public class AuthorizationRequestTest {
         AuthorizationRequest request = new AuthorizationRequest.Builder(
                 getTestServiceConfig(),
                 TEST_CLIENT_ID,
-                AuthorizationRequest.RESPONSE_TYPE_CODE,
+                ResponseTypeValues.CODE,
                 TEST_APP_REDIRECT_URI)
                 .setCodeVerifier(new String(codeVerifier))
                 .build();
@@ -452,7 +452,7 @@ public class AuthorizationRequestTest {
         assertEquals("unexpected code verifier challenge method",
                 TEST_CODE_VERIFIER_CHALLENGE_METHOD, request.codeVerifierChallengeMethod);
         assertEquals("unexpected response type",
-                AuthorizationRequest.RESPONSE_TYPE_CODE,
+                ResponseTypeValues.CODE,
                 request.responseType);
         assertEquals("unexpected response mode",
                 AuthorizationRequest.RESPONSE_MODE_QUERY,

--- a/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
@@ -55,6 +55,7 @@ public class AuthorizationServiceConfigurationTest {
     private static final String TEST_ISSUER = "test_issuer";
     private static final String TEST_AUTH_ENDPOINT = "https://test.openid.com/o/oauth/auth";
     private static final String TEST_TOKEN_ENDPOINT = "https://test.openid.com/o/oauth/token";
+    private static final String TEST_REGISTRATION_ENDPOINT = "https://test.openid.com/o/oauth/registration";
     private static final String TEST_USERINFO_ENDPOINT = "https://test.openid.com/o/oauth/userinfo";
     private static final String TEST_JWKS_URI = "https://test.openid.com/o/oauth/jwks";
     private static final List<String> TEST_RESPONSE_TYPE_SUPPORTED = Arrays.asList("code", "token");
@@ -70,6 +71,7 @@ public class AuthorizationServiceConfigurationTest {
             + " \"issuer\": \"" + TEST_ISSUER + "\",\n"
             + " \"authorization_endpoint\": \"" + TEST_AUTH_ENDPOINT + "\",\n"
             + " \"token_endpoint\": \"" + TEST_TOKEN_ENDPOINT + "\",\n"
+            + " \"registration_endpoint\": \"" + TEST_REGISTRATION_ENDPOINT + "\",\n"
             + " \"userinfo_endpoint\": \"" + TEST_USERINFO_ENDPOINT + "\",\n"
             + " \"jwks_uri\": \"" + TEST_JWKS_URI + "\",\n"
             + " \"response_types_supported\": " + toJson(TEST_RESPONSE_TYPE_SUPPORTED) + ",\n"
@@ -125,7 +127,8 @@ public class AuthorizationServiceConfigurationTest {
         mCallback = new RetrievalCallback();
         mConfig = new AuthorizationServiceConfiguration(
                 Uri.parse(TEST_AUTH_ENDPOINT),
-                Uri.parse(TEST_TOKEN_ENDPOINT));
+                Uri.parse(TEST_TOKEN_ENDPOINT),
+                Uri.parse(TEST_REGISTRATION_ENDPOINT));
     }
 
     @Test
@@ -161,6 +164,7 @@ public class AuthorizationServiceConfigurationTest {
     private void assertMembers(AuthorizationServiceConfiguration config) {
         assertEquals(TEST_AUTH_ENDPOINT, config.authorizationEndpoint.toString());
         assertEquals(TEST_TOKEN_ENDPOINT, config.tokenEndpoint.toString());
+        assertEquals(TEST_REGISTRATION_ENDPOINT, config.registrationEndpoint.toString());
     }
 
     @Test

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -15,7 +15,6 @@
 package net.openid.appauth;
 
 import static net.openid.appauth.TestValues.TEST_ACCESS_TOKEN;
-import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
 import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
 import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
 import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET_EXPIRES_AT;
@@ -250,7 +249,8 @@ public class AuthorizationServiceTest {
         assertEquals(TEST_ID_TOKEN, response.idToken);
     }
 
-    private void assertRegistrationResponse(RegistrationResponse response, RegistrationRequest expectedRequest) {
+    private void assertRegistrationResponse(RegistrationResponse response,
+                                            RegistrationRequest expectedRequest) {
         assertThat(response).isNotNull();
         assertThat(response.request).isEqualTo(expectedRequest);
         assertThat(response.clientId).isEqualTo(TEST_CLIENT_ID);

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -15,12 +15,18 @@
 package net.openid.appauth;
 
 import static net.openid.appauth.TestValues.TEST_ACCESS_TOKEN;
+import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
+import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET_EXPIRES_AT;
+import static net.openid.appauth.TestValues.TEST_IDP_REGISTRATION_ENDPOINT;
 import static net.openid.appauth.TestValues.TEST_IDP_TOKEN_ENDPOINT;
 import static net.openid.appauth.TestValues.TEST_ID_TOKEN;
 import static net.openid.appauth.TestValues.TEST_REFRESH_TOKEN;
 import static net.openid.appauth.TestValues.TEST_STATE;
 import static net.openid.appauth.TestValues.getTestAuthCodeExchangeRequest;
 import static net.openid.appauth.TestValues.getTestAuthRequestBuilder;
+import static net.openid.appauth.TestValues.getTestRegistrationRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -81,8 +87,16 @@ public class AuthorizationServiceTest {
             + "  \"token_type\": \"" + AuthorizationResponse.TOKEN_TYPE_BEARER + "\"\n"
             + "}";
 
+    private static final String REGISTRATION_RESPONSE_JSON = "{\n"
+            + " \"client_id\": \"" + TEST_CLIENT_ID + "\",\n"
+            + " \"client_secret\": \"" + TEST_CLIENT_SECRET + "\",\n"
+            + " \"client_secret_expires_at\": \"" + TEST_CLIENT_SECRET_EXPIRES_AT + "\",\n"
+            + " \"application_type\": " + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\n"
+            + "}";
+
     private URL mUrl;
     private AuthorizationCallback mAuthCallback;
+    private RegistrationCallback mRegistrationCallback;
     private AuthorizationService mService;
     private InjectedUrlBuilder mBuilder;
     private OutputStream mOutputStream;
@@ -105,6 +119,7 @@ public class AuthorizationServiceTest {
         };
         mUrl = new URL("foo", "bar", -1, "/foobar", urlStreamHandler);
         mAuthCallback = new AuthorizationCallback();
+        mRegistrationCallback = new RegistrationCallback();
         mBuilder = new InjectedUrlBuilder();
         mService = new AuthorizationService(mContext, mBuilder, mBrowserHandler);
         mOutputStream = new ByteArrayOutputStream();
@@ -185,6 +200,29 @@ public class AuthorizationServiceTest {
         assertEquals(GeneralErrors.NETWORK_ERROR, mAuthCallback.error);
     }
 
+    @Test
+    public void testRegistrationRequest() throws Exception {
+        InputStream is = new ByteArrayInputStream(REGISTRATION_RESPONSE_JSON.getBytes());
+        when(mHttpConnection.getInputStream()).thenReturn(is);
+        RegistrationRequest request = getTestRegistrationRequest();
+        mService.performRegistrationRequest(request, mRegistrationCallback);
+        mRegistrationCallback.waitForCallback();
+        assertRegistrationResponse(mRegistrationCallback.response, request);
+        String postBody = mOutputStream.toString();
+        assertThat(postBody).isEqualTo(request.toJsonString());
+        assertEquals(TEST_IDP_REGISTRATION_ENDPOINT.toString(), mBuilder.mUri);
+    }
+
+    @Test
+    public void testRegistrationRequest_IoException() throws Exception {
+        Exception ex = new IOException();
+        when(mHttpConnection.getInputStream()).thenThrow(ex);
+        mService.performRegistrationRequest(getTestRegistrationRequest(), mRegistrationCallback);
+        mRegistrationCallback.waitForCallback();
+        assertNotNull(mRegistrationCallback.error);
+        assertEquals(GeneralErrors.NETWORK_ERROR, mRegistrationCallback.error);
+    }
+
     @Test(expected = IllegalStateException.class)
     public void testTokenRequest_afterDispose() throws Exception {
         mService.dispose();
@@ -212,6 +250,14 @@ public class AuthorizationServiceTest {
         assertEquals(TEST_ID_TOKEN, response.idToken);
     }
 
+    private void assertRegistrationResponse(RegistrationResponse response, RegistrationRequest expectedRequest) {
+        assertThat(response).isNotNull();
+        assertThat(response.request).isEqualTo(expectedRequest);
+        assertThat(response.clientId).isEqualTo(TEST_CLIENT_ID);
+        assertThat(response.clientSecret).isEqualTo(TEST_CLIENT_SECRET);
+        assertThat(response.clientSecretExpiresAt).isEqualTo(TEST_CLIENT_SECRET_EXPIRES_AT);
+    }
+
     private class InjectedUrlBuilder implements AuthorizationService.UrlBuilder {
         public String mUri;
 
@@ -233,6 +279,28 @@ public class AuthorizationServiceTest {
                 @Nullable AuthorizationException ex) {
             assertTrue((tokenResponse == null) ^ (ex == null));
             this.response = tokenResponse;
+            this.error = ex;
+            mSemaphore.release();
+        }
+
+        public void waitForCallback() throws Exception {
+            assertTrue(mSemaphore.tryAcquire(CALLBACK_TIMEOUT_MILLIS,
+                    TimeUnit.MILLISECONDS));
+        }
+    }
+
+    private static class RegistrationCallback implements
+            AuthorizationService.RegistrationResponseCallback {
+        private Semaphore mSemaphore = new Semaphore(0);
+        public RegistrationResponse response;
+        public AuthorizationException error;
+
+        @Override
+        public void onRegistrationRequestCompleted(
+                @Nullable RegistrationResponse registrationResponse,
+                @Nullable AuthorizationException ex) {
+            assertTrue((registrationResponse == null) ^ (ex == null));
+            this.response = registrationResponse;
             this.error = ex;
             mSemaphore.release();
         }

--- a/library/javatests/net/openid/appauth/PreconditionsTest.java
+++ b/library/javatests/net/openid/appauth/PreconditionsTest.java
@@ -33,8 +33,6 @@ import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -132,6 +130,7 @@ public class PreconditionsTest {
     public void testCheckCollectionNotEmpty_withEmptyList() {
         checkCollectionNotEmpty(new ArrayList<Object>(), TEST_MSG);
     }
+
     @Test
     public void testCheckCollectionNotEmpty() {
         checkCollectionNotEmpty(Arrays.asList("value1", "value2"), TEST_MSG);

--- a/library/javatests/net/openid/appauth/PreconditionsTest.java
+++ b/library/javatests/net/openid/appauth/PreconditionsTest.java
@@ -15,6 +15,7 @@
 package net.openid.appauth;
 
 import static net.openid.appauth.Preconditions.checkArgument;
+import static net.openid.appauth.Preconditions.checkCollectionNotEmpty;
 import static net.openid.appauth.Preconditions.checkNotEmpty;
 import static net.openid.appauth.Preconditions.checkNotNull;
 import static net.openid.appauth.Preconditions.checkNullOrNotEmpty;
@@ -29,6 +30,11 @@ import org.junit.runner.RunWith;
 
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -115,5 +121,19 @@ public class PreconditionsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testCheckNullOrNotEmpty_emptyString() {
         checkNullOrNotEmpty("", TEST_MSG);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCheckCollectionNotEmpty_withNull() {
+        checkCollectionNotEmpty(null, TEST_MSG);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCheckCollectionNotEmpty_withEmptyList() {
+        checkCollectionNotEmpty(new ArrayList<Object>(), TEST_MSG);
+    }
+    @Test
+    public void testCheckCollectionNotEmpty() {
+        checkCollectionNotEmpty(Arrays.asList("value1", "value2"), TEST_MSG);
     }
 }

--- a/library/javatests/net/openid/appauth/RegistrationRequestTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationRequestTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openid.appauth;
 
 import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;

--- a/library/javatests/net/openid/appauth/RegistrationRequestTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationRequestTest.java
@@ -1,18 +1,10 @@
-/*
- * Copyright 2015 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package net.openid.appauth;
+
+import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
+import static net.openid.appauth.TestValues.TEST_APP_SCHEME;
+import static net.openid.appauth.TestValues.getTestServiceConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import android.net.Uri;
 
@@ -29,12 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
-import static net.openid.appauth.TestValues.TEST_APP_SCHEME;
-import static net.openid.appauth.TestValues.getTestServiceConfig;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -158,7 +144,8 @@ public class RegistrationRequestTest {
     public void testDeserialize() throws JSONException {
         mJson.put(RegistrationRequest.KEY_CONFIGURATION, getTestServiceConfig().toJson());
         RegistrationRequest request = RegistrationRequest.deserialize(mJson);
-        assertThat(request.configuration.toJsonString()).isEqualTo(getTestServiceConfig().toJsonString());
+        assertThat(request.configuration.toJsonString())
+                .isEqualTo(getTestServiceConfig().toJsonString());
         assertMaximalValuesInJson(request, mJson);
     }
 
@@ -168,7 +155,8 @@ public class RegistrationRequestTest {
         Map<String, String> additionalParameters = new HashMap<>();
         additionalParameters.put("key1", "value1");
         additionalParameters.put("key2", "value2");
-        mJson.put(RegistrationRequest.KEY_ADDITIONAL_PARAMETERS, JsonUtil.mapToJsonObject(additionalParameters));
+        mJson.put(RegistrationRequest.KEY_ADDITIONAL_PARAMETERS,
+                JsonUtil.mapToJsonObject(additionalParameters));
         RegistrationRequest request = RegistrationRequest.deserialize(mJson);
         assertThat(request.additionalParameters).isEqualTo(additionalParameters);
     }
@@ -180,7 +168,8 @@ public class RegistrationRequestTest {
                 request.applicationType);
     }
 
-    private void assertMaximalValuesInJson(RegistrationRequest request, JSONObject json) throws JSONException {
+    private void assertMaximalValuesInJson(RegistrationRequest request, JSONObject json)
+            throws JSONException {
         assertThat(json.get(RegistrationRequest.PARAM_REDIRECT_URIS))
                 .isEqualTo(JsonUtil.toJsonArray(request.redirectUris));
         assertThat(json.get(RegistrationRequest.PARAM_APPLICATION_TYPE))

--- a/library/javatests/net/openid/appauth/RegistrationRequestTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationRequestTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import android.net.Uri;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
+import static net.openid.appauth.TestValues.TEST_APP_SCHEME;
+import static net.openid.appauth.TestValues.getTestServiceConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class RegistrationRequestTest {
+
+    private static final Map<String, String> TEST_ADDITIONAL_PARAMS;
+
+    static {
+        TEST_ADDITIONAL_PARAMS = new HashMap<>();
+        TEST_ADDITIONAL_PARAMS.put("test_key1", "test_value1");
+        TEST_ADDITIONAL_PARAMS.put("test_key2", "test_value2");
+    }
+
+    private RegistrationRequest.Builder mMinimalRequestBuilder;
+
+    @Before
+    public void setUp() {
+        mMinimalRequestBuilder = new RegistrationRequest.Builder(
+                getTestServiceConfig(),
+                TEST_APP_REDIRECT_URI);
+    }
+
+    @Test
+    public void testBuilder() {
+        assertValues(mMinimalRequestBuilder.build());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuild_nullConfiguration() {
+        new RegistrationRequest.Builder(null, TEST_APP_REDIRECT_URI).build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuild_nullRedirectUri() {
+        new RegistrationRequest.Builder(getTestServiceConfig(), null)
+                .build();
+    }
+
+    @Test
+    public void testBuilder_setRedirectUriValues() {
+        Uri redirect1 = Uri.parse(TEST_APP_SCHEME + ":/callback1");
+        Uri redirect2 = Uri.parse(TEST_APP_SCHEME + ":/callback2");
+        mMinimalRequestBuilder.setRedirectUriValues(redirect1, redirect2);
+        RegistrationRequest request = mMinimalRequestBuilder.build();
+        assertThat(request.redirectUris.containsAll(Arrays.asList(redirect1, redirect2))).isTrue();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_setAdditionalParams_withBuiltInParam() {
+        Map<String, String> additionalParams = new HashMap<>();
+        additionalParams.put(RegistrationRequest.PARAM_APPLICATION_TYPE, "web");
+        mMinimalRequestBuilder.setAdditionalParameters(additionalParams);
+    }
+
+    @Test
+    public void testApplicationTypeIsNativeByDefault() {
+        RegistrationRequest request = mMinimalRequestBuilder.build();
+        assertThat(request.applicationType).isEqualTo(RegistrationRequest.APPLICATION_TYPE_NATIVE);
+    }
+
+    @Test
+    public void testToJsonString_withAdditionalParameters() throws JSONException {
+        RegistrationRequest request = mMinimalRequestBuilder
+                .setAdditionalParameters(TEST_ADDITIONAL_PARAMS)
+                .build();
+        String jsonStr = request.toJsonString();
+
+        JSONObject json = new JSONObject(jsonStr);
+        for (Map.Entry<String, String> param : TEST_ADDITIONAL_PARAMS.entrySet()) {
+            assertThat(json.get(param.getKey())).isEqualTo(param.getValue());
+        }
+
+        assertThat(request.applicationType).isEqualTo(RegistrationRequest.APPLICATION_TYPE_NATIVE);
+    }
+
+    @Test
+    public void testToJsonString() throws JSONException {
+        RegistrationRequest request = mMinimalRequestBuilder
+                .setResponseTypeValues(ResponseTypeValues.ID_TOKEN)
+                .setGrantTypeValues(GrantTypeValues.IMPLICIT)
+                .setSubjectType(RegistrationRequest.SUBJECT_TYPE_PAIRWISE)
+                .build();
+        String jsonStr = request.toJsonString();
+
+        JSONObject json = new JSONObject(jsonStr);
+        assertThat(json.get(RegistrationRequest.PARAM_REDIRECT_URIS))
+                .isEqualTo(JsonUtil.toJsonArray(request.redirectUris));
+        assertThat(json.get(RegistrationRequest.PARAM_APPLICATION_TYPE))
+                .isEqualTo(request.APPLICATION_TYPE_NATIVE);
+        assertThat(json.get(RegistrationRequest.PARAM_RESPONSE_TYPES))
+                .isEqualTo(JsonUtil.toJsonArray(request.responseTypes));
+        assertThat(json.get(RegistrationRequest.PARAM_GRANT_TYPES))
+                .isEqualTo(JsonUtil.toJsonArray(request.grantTypes));
+        assertThat(json.get(RegistrationRequest.PARAM_SUBJECT_TYPE))
+                .isEqualTo(request.subjectType);
+    }
+
+
+    private void assertValues(RegistrationRequest request) {
+        assertEquals("unexpected redirect URI", TEST_APP_REDIRECT_URI,
+                request.redirectUris.iterator().next());
+        assertEquals("unexpected application tyoe", RegistrationRequest.APPLICATION_TYPE_NATIVE,
+                request.applicationType);
+    }
+}

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -1,0 +1,134 @@
+package net.openid.appauth;
+
+import android.net.Uri;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
+import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET_EXPIRES_AT;
+import static net.openid.appauth.TestValues.getTestServiceConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+@RunWith(Enclosed.class)
+@Config(manifest = Config.NONE)
+public class RegistrationResponseTest {
+    private static final Long TEST_CLIENT_ID_ISSUED_AT = 34L;
+    private static final String TEST_REGISTRATION_ACCESS_TOKEN = "test_access_token";
+    private static final String TEST_REGISTRATION_CLIENT_URI = "https://test.openid.com/register?client_id=" + TEST_CLIENT_ID;
+
+
+    private static final String TEST_JSON = "{\n"
+            + " \"client_id\": \"" + TEST_CLIENT_ID + "\",\n"
+            + " \"client_id_issued_at\": \"" + TEST_CLIENT_ID_ISSUED_AT + "\",\n"
+            + " \"client_secret\": \"" + TEST_CLIENT_SECRET + "\",\n"
+            + " \"client_secret_expires_at\": \"" + TEST_CLIENT_SECRET_EXPIRES_AT + "\",\n"
+            + " \"registration_access_token\": \"" + TEST_REGISTRATION_ACCESS_TOKEN + "\",\n"
+            + " \"registration_client_uri\": \"" + TEST_REGISTRATION_CLIENT_URI + "\",\n"
+            + " \"application_type\": " + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\n"
+            + "}";
+
+    @RunWith(RobolectricTestRunner.class)
+    @Config(manifest = Config.NONE)
+    public static class RegistrationResponseSingleTest {
+        private RegistrationResponse.Builder mMinimalBuilder;
+        private RegistrationRequest mMinimalRegistrationRequest;
+        private JSONObject mJson;
+
+        @Before
+        public void setUp() throws Exception {
+            mJson = new JSONObject(TEST_JSON);
+            mMinimalRegistrationRequest = new RegistrationRequest.Builder(getTestServiceConfig(),
+                    TEST_APP_REDIRECT_URI)
+                    .build();
+            mMinimalBuilder = new RegistrationResponse.Builder(mMinimalRegistrationRequest);
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testBuilder_setAdditionalParams_withBuiltInParam() {
+            mMinimalBuilder.setAdditionalParameters(
+                    Collections.singletonMap(RegistrationResponse.PARAM_CLIENT_ID, "client1"));
+        }
+
+        @Test
+        public void testFromJson() throws Exception {
+            RegistrationResponse response = RegistrationResponse.fromJson(mMinimalRegistrationRequest, mJson);
+            assertThat(response.clientId).isEqualTo(TEST_CLIENT_ID);
+            assertThat(response.clientIdIssuedAt).isEqualTo(TEST_CLIENT_ID_ISSUED_AT);
+            assertThat(response.clientSecret).isEqualTo(TEST_CLIENT_SECRET);
+            assertThat(response.clientSecretExpiresAt).isEqualTo(TEST_CLIENT_SECRET_EXPIRES_AT);
+            assertThat(response.registrationAccessToken).isEqualTo(TEST_REGISTRATION_ACCESS_TOKEN);
+            assertThat(response.registrationClientUri).isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
+            assertThat(response.additionalParameters.get("application_type")).isEqualTo(RegistrationRequest.APPLICATION_TYPE_NATIVE);
+        }
+
+        @Test
+        public void testHasExpired_withValidClientSecret() throws Exception {
+            RegistrationResponse response = RegistrationResponse.fromJson(mMinimalRegistrationRequest, mJson);
+            assertThat(response.hasClientSecretExpired(new TestClock(TimeUnit.SECONDS.toMillis(TEST_CLIENT_SECRET_EXPIRES_AT - 1L)))).isFalse();
+        }
+
+        @Test
+        public void testHasExpired_withExpiredClientSecret() throws Exception {
+            RegistrationResponse response = RegistrationResponse.fromJson(mMinimalRegistrationRequest, mJson);
+            assertThat(response.hasClientSecretExpired(new TestClock(TimeUnit.SECONDS.toMillis(TEST_CLIENT_SECRET_EXPIRES_AT + 1L)))).isTrue();
+        }
+    }
+
+    @RunWith(ParameterizedRobolectricTestRunner.class)
+    @Config(manifest = Config.NONE)
+    public static class RegistrationResponseParameterTest {
+        private JSONObject mJson;
+        private RegistrationRequest mMinimalRegistrationRequest;
+
+        @Before
+        public void setUp() throws Exception {
+            mJson = new JSONObject(TEST_JSON);
+            mMinimalRegistrationRequest = new RegistrationRequest.Builder(getTestServiceConfig(),
+                    TEST_APP_REDIRECT_URI)
+                    .build();
+        }
+
+        @Test
+        public void testBuilder_fromJSONWithMissingRequiredParameter() throws Exception {
+            mJson.remove(missingParameter);
+            try {
+                RegistrationResponse.fromJson(mMinimalRegistrationRequest, mJson);
+                fail("Expected MissingArgumentException not thrown.");
+            } catch (RegistrationResponse.MissingArgumentException e) {
+                assertThat(missingParameter).isEqualTo(e.getMissingField());
+            }
+        }
+
+        @ParameterizedRobolectricTestRunner.Parameters(name = "Missing parameter = {0}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {RegistrationResponse.PARAM_CLIENT_SECRET_EXPIRES_AT},
+                    {RegistrationResponse.PARAM_REGISTRATION_ACCESS_TOKEN},
+                    {RegistrationResponse.PARAM_REGISTRATION_CLIENT_URI}
+            });
+        }
+
+        private String missingParameter;
+
+        public RegistrationResponseParameterTest(String missingParameter) {
+            this.missingParameter = missingParameter;
+        }
+    }
+}
+
+

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openid.appauth;
 
 import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -180,6 +180,9 @@ public class RegistrationResponseTest {
             }
         }
 
+        /**
+         * TODO .
+         */
         @ParameterizedRobolectricTestRunner.Parameters(name = "Missing parameter = {0}")
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{
@@ -191,6 +194,9 @@ public class RegistrationResponseTest {
 
         private String mMissingParameter;
 
+        /**
+         * TODO .
+         */
         public RegistrationResponseParameterTest(String missingParameter) {
             mMissingParameter = missingParameter;
         }

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -1,5 +1,14 @@
 package net.openid.appauth;
 
+import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
+import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET_EXPIRES_AT;
+import static net.openid.appauth.TestValues.getTestRegistrationRequest;
+import static net.openid.appauth.TestValues.getTestServiceConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
 import android.net.Uri;
 
 import org.json.JSONObject;
@@ -17,21 +26,13 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
-import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
-import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
-import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET_EXPIRES_AT;
-import static net.openid.appauth.TestValues.getTestRegistrationRequest;
-import static net.openid.appauth.TestValues.getTestServiceConfig;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
 @RunWith(Enclosed.class)
 @Config(manifest = Config.NONE)
 public class RegistrationResponseTest {
     private static final Long TEST_CLIENT_ID_ISSUED_AT = 34L;
     private static final String TEST_REGISTRATION_ACCESS_TOKEN = "test_access_token";
-    private static final String TEST_REGISTRATION_CLIENT_URI = "https://test.openid.com/register?client_id=" + TEST_CLIENT_ID;
+    private static final String TEST_REGISTRATION_CLIENT_URI =
+            "https://test.openid.com/register?client_id=" + TEST_CLIENT_ID;
 
 
     private static final String TEST_JSON = "{\n"
@@ -64,20 +65,28 @@ public class RegistrationResponseTest {
 
         @Test
         public void testFromJson() throws Exception {
-            RegistrationResponse response = RegistrationResponse.fromJson(getTestRegistrationRequest(), mJson);
+            RegistrationResponse response = RegistrationResponse
+                    .fromJson(getTestRegistrationRequest(), mJson);
             assertValues(response);
         }
 
         @Test
         public void testSerialize() throws Exception {
-            JSONObject json = RegistrationResponse.fromJson(getTestRegistrationRequest(), mJson).serialize();
+            JSONObject json = RegistrationResponse.fromJson(getTestRegistrationRequest(), mJson)
+                    .serialize();
 
-            assertThat(json.get(RegistrationResponse.KEY_REQUEST).toString()).isEqualTo(getTestRegistrationRequest().serialize().toString());
-            assertThat(json.getLong(RegistrationResponse.PARAM_CLIENT_ID_ISSUED_AT)).isEqualTo(TEST_CLIENT_ID_ISSUED_AT);
-            assertThat(json.getString(RegistrationResponse.PARAM_CLIENT_SECRET)).isEqualTo(TEST_CLIENT_SECRET);
-            assertThat(json.getLong(RegistrationResponse.PARAM_CLIENT_SECRET_EXPIRES_AT)).isEqualTo(TEST_CLIENT_SECRET_EXPIRES_AT);
-            assertThat(json.getString(RegistrationResponse.PARAM_REGISTRATION_ACCESS_TOKEN)).isEqualTo(TEST_REGISTRATION_ACCESS_TOKEN);
-            assertThat(JsonUtil.getUri(json, RegistrationResponse.PARAM_REGISTRATION_CLIENT_URI)).isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
+            assertThat(json.get(RegistrationResponse.KEY_REQUEST).toString())
+                    .isEqualTo(getTestRegistrationRequest().serialize().toString());
+            assertThat(json.getLong(RegistrationResponse.PARAM_CLIENT_ID_ISSUED_AT))
+                    .isEqualTo(TEST_CLIENT_ID_ISSUED_AT);
+            assertThat(json.getString(RegistrationResponse.PARAM_CLIENT_SECRET))
+                    .isEqualTo(TEST_CLIENT_SECRET);
+            assertThat(json.getLong(RegistrationResponse.PARAM_CLIENT_SECRET_EXPIRES_AT))
+                    .isEqualTo(TEST_CLIENT_SECRET_EXPIRES_AT);
+            assertThat(json.getString(RegistrationResponse.PARAM_REGISTRATION_ACCESS_TOKEN))
+                    .isEqualTo(TEST_REGISTRATION_ACCESS_TOKEN);
+            assertThat(JsonUtil.getUri(json, RegistrationResponse.PARAM_REGISTRATION_CLIENT_URI))
+                    .isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
         }
 
         @Test
@@ -104,14 +113,18 @@ public class RegistrationResponseTest {
 
         @Test
         public void testHasExpired_withValidClientSecret() throws Exception {
-            RegistrationResponse response = RegistrationResponse.fromJson(getTestRegistrationRequest(), mJson);
-            assertThat(response.hasClientSecretExpired(new TestClock(TimeUnit.SECONDS.toMillis(TEST_CLIENT_SECRET_EXPIRES_AT - 1L)))).isFalse();
+            RegistrationResponse response = RegistrationResponse
+                    .fromJson(getTestRegistrationRequest(), mJson);
+            long now = TimeUnit.SECONDS.toMillis(TEST_CLIENT_SECRET_EXPIRES_AT - 1L);
+            assertThat(response.hasClientSecretExpired(new TestClock(now))).isFalse();
         }
 
         @Test
         public void testHasExpired_withExpiredClientSecret() throws Exception {
-            RegistrationResponse response = RegistrationResponse.fromJson(getTestRegistrationRequest(), mJson);
-            assertThat(response.hasClientSecretExpired(new TestClock(TimeUnit.SECONDS.toMillis(TEST_CLIENT_SECRET_EXPIRES_AT + 1L)))).isTrue();
+            RegistrationResponse response = RegistrationResponse
+                    .fromJson(getTestRegistrationRequest(), mJson);
+            long now = TimeUnit.SECONDS.toMillis(TEST_CLIENT_SECRET_EXPIRES_AT + 1L);
+            assertThat(response.hasClientSecretExpired(new TestClock(now))).isTrue();
         }
 
         private void assertValues(RegistrationResponse response) {
@@ -120,13 +133,16 @@ public class RegistrationResponseTest {
             assertThat(response.clientSecret).isEqualTo(TEST_CLIENT_SECRET);
             assertThat(response.clientSecretExpiresAt).isEqualTo(TEST_CLIENT_SECRET_EXPIRES_AT);
             assertThat(response.registrationAccessToken).isEqualTo(TEST_REGISTRATION_ACCESS_TOKEN);
-            assertThat(response.registrationClientUri).isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
-            assertThat(response.additionalParameters.get(RegistrationRequest.PARAM_APPLICATION_TYPE)).isEqualTo(RegistrationRequest.APPLICATION_TYPE_NATIVE);
+            assertThat(response.registrationClientUri)
+                    .isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
+            assertThat(response.additionalParameters)
+                    .containsEntry(RegistrationRequest.PARAM_APPLICATION_TYPE,
+                            RegistrationRequest.APPLICATION_TYPE_NATIVE);
         }
     }
 
     @RunWith(ParameterizedRobolectricTestRunner.class)
-    @Config(manifest=Config.NONE)
+    @Config(manifest = Config.NONE)
     public static class RegistrationResponseParameterTest {
         private JSONObject mJson;
         private RegistrationRequest mMinimalRegistrationRequest;
@@ -140,13 +156,13 @@ public class RegistrationResponseTest {
         }
 
         @Test
-        public void testBuilder_fromJSONWithMissingRequiredParameter() throws Exception {
-            mJson.remove(missingParameter);
+        public void testBuilder_fromJsonNWithMissingRequiredParameter() throws Exception {
+            mJson.remove(mMissingParameter);
             try {
                 RegistrationResponse.fromJson(mMinimalRegistrationRequest, mJson);
                 fail("Expected MissingArgumentException not thrown.");
             } catch (RegistrationResponse.MissingArgumentException e) {
-                assertThat(missingParameter).isEqualTo(e.getMissingField());
+                assertThat(mMissingParameter).isEqualTo(e.getMissingField());
             }
         }
 
@@ -159,10 +175,10 @@ public class RegistrationResponseTest {
             });
         }
 
-        private String missingParameter;
+        private String mMissingParameter;
 
         public RegistrationResponseParameterTest(String missingParameter) {
-            this.missingParameter = missingParameter;
+            mMissingParameter = missingParameter;
         }
     }
 }

--- a/library/javatests/net/openid/appauth/TestValues.java
+++ b/library/javatests/net/openid/appauth/TestValues.java
@@ -16,6 +16,9 @@ package net.openid.appauth;
 
 import android.net.Uri;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 /**
  * Contains common test values which are useful across all tests.
  */
@@ -106,7 +109,8 @@ class TestValues {
     }
 
     public static RegistrationRequest.Builder getTestRegistrationRequestBuilder() {
-        return new RegistrationRequest.Builder(getTestServiceConfig(), TEST_APP_REDIRECT_URI);
+        return new RegistrationRequest.Builder(getTestServiceConfig(),
+                Arrays.asList(TEST_APP_REDIRECT_URI));
     }
 
     public static RegistrationRequest getTestRegistrationRequest() {

--- a/library/javatests/net/openid/appauth/TestValues.java
+++ b/library/javatests/net/openid/appauth/TestValues.java
@@ -40,6 +40,9 @@ class TestValues {
     public static final String TEST_ID_TOKEN = "abc.def.ghi";
     public static final String TEST_REFRESH_TOKEN = "asdfghjkl";
 
+    public static final Long TEST_CLIENT_SECRET_EXPIRES_AT = 78L;
+    public static final String TEST_CLIENT_SECRET = "test_client_secret";
+
     public static AuthorizationServiceConfiguration getTestServiceConfig() {
         return new AuthorizationServiceConfiguration(
                 TEST_IDP_AUTH_ENDPOINT,
@@ -100,5 +103,13 @@ class TestValues {
 
     public static TokenResponse getTestAuthCodeExchangeResponse() {
         return getTestAuthCodeExchangeResponseBuilder().build();
+    }
+
+    public static RegistrationRequest.Builder getTestRegistrationRequestBuilder() {
+        return new RegistrationRequest.Builder(getTestServiceConfig(), TEST_APP_REDIRECT_URI);
+    }
+
+    public static RegistrationRequest getTestRegistrationRequest() {
+        return getTestRegistrationRequestBuilder().build();
     }
 }

--- a/library/javatests/net/openid/appauth/TestValues.java
+++ b/library/javatests/net/openid/appauth/TestValues.java
@@ -17,7 +17,6 @@ package net.openid.appauth;
 import android.net.Uri;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 /**
  * Contains common test values which are useful across all tests.

--- a/library/javatests/net/openid/appauth/TestValues.java
+++ b/library/javatests/net/openid/appauth/TestValues.java
@@ -30,6 +30,8 @@ class TestValues {
             Uri.parse("https://testidp.example.com/authorize");
     public static final Uri TEST_IDP_TOKEN_ENDPOINT =
             Uri.parse("https://testidp.example.com/token");
+    public static final Uri TEST_IDP_REGISTRATION_ENDPOINT =
+            Uri.parse("https://testidp.example.com/token");
 
     public static final String TEST_CODE_VERIFIER = "0123456789_0123456789_0123456789_0123456789";
     public static final String TEST_AUTH_CODE = "zxcvbnmjk";
@@ -41,7 +43,8 @@ class TestValues {
     public static AuthorizationServiceConfiguration getTestServiceConfig() {
         return new AuthorizationServiceConfiguration(
                 TEST_IDP_AUTH_ENDPOINT,
-                TEST_IDP_TOKEN_ENDPOINT);
+                TEST_IDP_TOKEN_ENDPOINT,
+                TEST_IDP_REGISTRATION_ENDPOINT);
     }
 
     public static AuthorizationRequest.Builder getMinimalAuthRequestBuilder(String responseType) {
@@ -53,7 +56,7 @@ class TestValues {
     }
 
     public static AuthorizationRequest.Builder getTestAuthRequestBuilder() {
-        return getMinimalAuthRequestBuilder(AuthorizationRequest.RESPONSE_TYPE_CODE)
+        return getMinimalAuthRequestBuilder(ResponseTypeValues.CODE)
                 .setScopes(AuthorizationRequest.SCOPE_OPENID, AuthorizationRequest.SCOPE_EMAIL)
                 .setCodeVerifier(TEST_CODE_VERIFIER);
     }
@@ -81,7 +84,7 @@ class TestValues {
         return getMinimalTokenRequestBuilder()
                 .setAuthorizationCode(TEST_AUTH_CODE)
                 .setCodeVerifier(TEST_CODE_VERIFIER)
-                .setGrantType(TokenRequest.GRANT_TYPE_AUTHORIZATION_CODE)
+                .setGrantType(GrantTypeValues.AUTHORIZATION_CODE)
                 .setRedirectUri(TEST_APP_REDIRECT_URI);
     }
 

--- a/library/javatests/net/openid/appauth/TokenRequestTest.java
+++ b/library/javatests/net/openid/appauth/TokenRequestTest.java
@@ -123,7 +123,7 @@ public class TokenRequestTest {
         Map<String, String> params = request.getRequestParameters();
         assertThat(params).containsEntry(
                 TokenRequest.PARAM_GRANT_TYPE,
-                TokenRequest.GRANT_TYPE_AUTHORIZATION_CODE);
+                GrantTypeValues.AUTHORIZATION_CODE);
         assertThat(params).containsEntry(
                 TokenRequest.PARAM_CLIENT_ID,
                 TEST_CLIENT_ID);
@@ -144,7 +144,7 @@ public class TokenRequestTest {
         Map<String, String> params = request.getRequestParameters();
         assertThat(params).containsEntry(
                 TokenRequest.PARAM_GRANT_TYPE,
-                TokenRequest.GRANT_TYPE_REFRESH_TOKEN);
+                GrantTypeValues.REFRESH_TOKEN);
         assertThat(params).containsEntry(
                 TokenRequest.PARAM_CLIENT_ID,
                 TEST_CLIENT_ID);


### PR DESCRIPTION
A basis for implementation of OIDC dynamic client registration according to [specs](https://openid.net/specs/openid-connect-registration-1_0.html).

What's done:
* Registration Request/Registration Response representation.
* AsyncTask for sending the request.
* Example in the demo app of how it can be used.

Still missing:
* Documentation/references to the valid sections of the specification.
* Maybe this could be generalized to also support [OAuth 2.0 Dynamic client registration](https://tools.ietf.org/html/rfc7591). I haven't verified how far off it might be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/40)
<!-- Reviewable:end -->
