### PR TITLE
[WIP] Support client authentication at token endpoint

### DIFF
--- a/app/src/net/openid/appauthdemo/MainActivity.java
+++ b/app/src/net/openid/appauthdemo/MainActivity.java
@@ -33,6 +33,7 @@ import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationRequest;
 import net.openid.appauth.AuthorizationService;
 import net.openid.appauth.AuthorizationServiceConfiguration;
+import net.openid.appauth.ClientSecretBasic;
 import net.openid.appauth.RegistrationRequest;
 import net.openid.appauth.RegistrationResponse;
 import net.openid.appauth.ResponseTypeValues;
@@ -142,7 +143,8 @@ public class MainActivity extends AppCompatActivity {
                 TokenActivity.createPostAuthorizationIntent(
                         this,
                         authRequest,
-                        serviceConfig.discoveryDoc),
+                        serviceConfig.discoveryDoc,
+                        idp.getClientSecret()),
                 mAuthService.createCustomTabsIntentBuilder()
                         .setToolbarColor(getColorCompat(R.color.colorAccent))
                         .build());
@@ -151,10 +153,13 @@ public class MainActivity extends AppCompatActivity {
     private void makeRegistrationRequest(
             @NonNull AuthorizationServiceConfiguration serviceConfig,
             @NonNull final IdentityProvider idp) {
+
         final RegistrationRequest registrationRequest = new RegistrationRequest.Builder(
                 serviceConfig,
                 Arrays.asList(idp.getRedirectUri()))
+                .setTokenEndpointAuthenticationMethod(ClientSecretBasic.NAME)
                 .build();
+
         Log.d(TAG, "Making registration request to " + serviceConfig.registrationEndpoint);
         mAuthService.performRegistrationRequest(
                 registrationRequest,

--- a/library/java/net/openid/appauth/ClientAuthentication.java
+++ b/library/java/net/openid/appauth/ClientAuthentication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import java.util.Map;
+
+public interface ClientAuthentication {
+    /**
+     * Constructs any extra parameters necessary to include in the request headers for the client
+     * authentication.
+     */
+    Map<String, String> getRequestHeaders(String clientId);
+
+    /**
+     * Constructs any extra parameters necessary to include in the request body for the client
+     * authentication.
+     */
+    Map<String, String> getRequestParameters(String clientId);
+}

--- a/library/java/net/openid/appauth/ClientSecretBasic.java
+++ b/library/java/net/openid/appauth/ClientSecretBasic.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import static net.openid.appauth.Preconditions.checkNotNull;
+
+import android.support.annotation.NonNull;
+import android.util.Base64;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Implementation of the client authentication method 'client_secret_basic'.
+ *
+ * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+ * "OpenID Connect Core 1.0", Section 9</a>
+ */
+public class ClientSecretBasic implements ClientAuthentication {
+    /**
+     * Name of this authentication method.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+     * "OpenID Connect Core 1.0", Section 9</a>
+     */
+    public static final String NAME = "client_secret_basic";
+
+    @NonNull
+    private String mClientSecret;
+
+    /**
+     * Creates a {@link ClientAuthentication} which will use the client authentication method
+     * 'client_secret_basic'.
+     */
+    public ClientSecretBasic(@NonNull String clientSecret) {
+        mClientSecret = checkNotNull(clientSecret, "mClientSecret cannot be null");
+    }
+
+    @Override
+    public final Map<String, String> getRequestHeaders(String clientId) {
+        String credentials = clientId + ":" + mClientSecret;
+        String basicAuth = Base64.encodeToString(credentials.getBytes(), Base64.NO_WRAP);
+        return Collections.singletonMap("Authorization", "Basic " + basicAuth);
+    }
+
+    @Override
+    public final Map<String, String> getRequestParameters(String clientId) {
+        return null;
+    }
+}

--- a/library/java/net/openid/appauth/ClientSecretPost.java
+++ b/library/java/net/openid/appauth/ClientSecretPost.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import static net.openid.appauth.Preconditions.checkNotNull;
+
+import android.support.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Implementation of the client authentication method 'client_secret_post'.
+ *
+ * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+ * "OpenID Connect Core 1.0", Section 9</a>
+ */
+public class ClientSecretPost implements ClientAuthentication {
+    /**
+     * Name of this authentication method.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+     * "OpenID Connect Core 1.0", Section 9</a>
+     */
+    public static final String NAME = "client_secret_post";
+    static final String PARAM_CLIENT_ID = "client_id";
+    static final String PARAM_CLIENT_SECRET = "client_secret";
+
+    @NonNull
+    private String mClientSecret;
+
+    /**
+     * Creates a {@link ClientAuthentication} which will use the client authentication method
+     * 'client_secret_post'.
+     */
+    public ClientSecretPost(@NonNull String clientSecret) {
+        mClientSecret = checkNotNull(clientSecret, "clientSecret cannot be null");
+    }
+
+    @Override
+    public final Map<String, String> getRequestParameters(String clientId) {
+        Map<String, String> additionalParameters = new HashMap<>();
+        additionalParameters.put(PARAM_CLIENT_ID, clientId);
+        additionalParameters.put(PARAM_CLIENT_SECRET, mClientSecret);
+        return additionalParameters;
+    }
+
+    @Override
+    public final Map<String, String> getRequestHeaders(String clientId) {
+        return null;
+    }
+}

--- a/library/java/net/openid/appauth/GrantTypeValues.java
+++ b/library/java/net/openid/appauth/GrantTypeValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/library/java/net/openid/appauth/NoClientAuthentication.java
+++ b/library/java/net/openid/appauth/NoClientAuthentication.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import java.util.Map;
+
+/**
+ * Implementation of the client authentication method 'none'. This is the default,
+ * if no other authentication method is specified when calling
+ * {@link AuthorizationService#performTokenRequest(TokenRequest,
+ * AuthorizationService.TokenResponseCallback)}.
+ *
+ * @see @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+ * "OpenID Connect Core 1.0", Section 9</a>
+ */
+public class NoClientAuthentication implements ClientAuthentication {
+    /**
+     * Name of this authentication method.
+     */
+    public static final String NAME = "none";
+
+    /**
+     * The default (singleton) instance of {@linke NoClientAuthentication}.
+     */
+    public static final NoClientAuthentication INSTANCE = new NoClientAuthentication();
+
+    private NoClientAuthentication() {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return always null.
+     */
+    @Override
+    public Map<String, String> getRequestHeaders(String clientId) {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return always null.
+     */
+    @Override
+    public Map<String, String> getRequestParameters(String clientId) {
+        return null;
+    }
+}

--- a/library/java/net/openid/appauth/RegistrationRequest.java
+++ b/library/java/net/openid/appauth/RegistrationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -45,13 +45,15 @@ public class RegistrationRequest {
     static final String PARAM_GRANT_TYPES = "grant_types";
     static final String PARAM_APPLICATION_TYPE = "application_type";
     static final String PARAM_SUBJECT_TYPE = "subject_type";
+    static final String PARAM_TOKEN_ENDPOINT_AUTHENTICATION_METHOD = "token_endpoint_auth_method";
 
     private static final Set<String> BUILT_IN_PARAMS = builtInParams(
             PARAM_REDIRECT_URIS,
             PARAM_RESPONSE_TYPES,
             PARAM_GRANT_TYPES,
             PARAM_APPLICATION_TYPE,
-            PARAM_SUBJECT_TYPE
+            PARAM_SUBJECT_TYPE,
+            PARAM_TOKEN_ENDPOINT_AUTHENTICATION_METHOD
     );
 
     static final String KEY_ADDITIONAL_PARAMETERS = "additionalParameters";
@@ -72,7 +74,6 @@ public class RegistrationRequest {
      * "OpenID Connect Core 1.0", Section 8</a>
      */
     public static final String SUBJECT_TYPE_PUBLIC = "public";
-
 
     /**
      * The service's {@link AuthorizationServiceConfiguration configuration}.
@@ -131,6 +132,15 @@ public class RegistrationRequest {
     public final String subjectType;
 
     /**
+     * The client authentication method to use at the token endpoint.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+     * "OpenID Connect Core 1.0", Section 9</a>
+     */
+    @Nullable
+    public final String tokenEndpointAuthenticationMethod;
+
+    /**
      * Additional parameters to be passed as part of the request.
      */
     @NonNull
@@ -154,6 +164,9 @@ public class RegistrationRequest {
 
         @Nullable
         private String mSubjectType;
+
+        @Nullable
+        private String mTokenEndpointAuthenticationMethod;
 
         @NonNull
         private Map<String, String> mAdditionalParameters = Collections.emptyMap();
@@ -230,7 +243,7 @@ public class RegistrationRequest {
          * Specifies the grant types.
          *
          * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata">
-          * "OpenID Connect Dynamic Client Registration 1.0", Section 2</a>
+         * "OpenID Connect Dynamic Client Registration 1.0", Section 2</a>
          */
         @NonNull
         public Builder setGrantTypeValues(@Nullable String... grantTypeValues) {
@@ -253,11 +266,24 @@ public class RegistrationRequest {
          * Specifies the subject types.
          *
          * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes">
-          * "OpenID Connect Core 1.0", Section 8</a>l
+         * "OpenID Connect Core 1.0", Section 8</a>l
          */
         @NonNull
         public Builder setSubjectType(@Nullable String subjectType) {
             mSubjectType = subjectType;
+            return this;
+        }
+
+        /**
+         * Specifies the client authentication method to use at the token endpoint.
+         *
+         * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+         * "OpenID Connect Core 1.0", Section 9</a>
+         */
+        @NonNull
+        public Builder setTokenEndpointAuthenticationMethod(
+                @Nullable String tokenEndpointAuthenticationMethod) {
+            this.mTokenEndpointAuthenticationMethod = tokenEndpointAuthenticationMethod;
             return this;
         }
 
@@ -286,6 +312,7 @@ public class RegistrationRequest {
                             ? mResponseTypes : Collections.unmodifiableList(mResponseTypes),
                     mGrantTypes == null ? mGrantTypes : Collections.unmodifiableList(mGrantTypes),
                     mSubjectType,
+                    mTokenEndpointAuthenticationMethod,
                     Collections.unmodifiableMap(mAdditionalParameters));
         }
     }
@@ -296,12 +323,14 @@ public class RegistrationRequest {
             @Nullable List<String> responseTypes,
             @Nullable List<String> grantTypes,
             @Nullable String subjectType,
+            @Nullable String tokenEndpointAuthenticationMethod,
             @NonNull Map<String, String> additionalParameters) {
         this.configuration = configuration;
         this.redirectUris = redirectUris;
         this.responseTypes = responseTypes;
         this.grantTypes = grantTypes;
         this.subjectType = subjectType;
+        this.tokenEndpointAuthenticationMethod = tokenEndpointAuthenticationMethod;
         this.additionalParameters = additionalParameters;
         this.applicationType = APPLICATION_TYPE_NATIVE;
     }
@@ -344,6 +373,8 @@ public class RegistrationRequest {
             JsonUtil.put(json, PARAM_GRANT_TYPES, JsonUtil.toJsonArray(grantTypes));
         }
         JsonUtil.putIfNotNull(json, PARAM_SUBJECT_TYPE, subjectType);
+        JsonUtil.putIfNotNull(json, PARAM_TOKEN_ENDPOINT_AUTHENTICATION_METHOD,
+                tokenEndpointAuthenticationMethod);
         return json;
     }
 

--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/library/java/net/openid/appauth/ResponseTypeValues.java
+++ b/library/java/net/openid/appauth/ResponseTypeValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/library/java/net/openid/appauth/TokenRequest.java
+++ b/library/java/net/openid/appauth/TokenRequest.java
@@ -494,9 +494,8 @@ public class TokenRequest {
      * Produces the set of request parameters for this query, which can be further
      * processed into a request body.
      */
-    @VisibleForTesting
     @NonNull
-    Map<String, String> getRequestParameters() {
+    public Map<String, String> getRequestParameters() {
         Map<String, String> params = new HashMap<>();
         params.put(PARAM_GRANT_TYPE, grantType);
         params.put(PARAM_CLIENT_ID, clientId);
@@ -517,24 +516,6 @@ public class TokenRequest {
         if (value != null) {
             map.put(key, value.toString());
         }
-    }
-
-    /**
-     * Produces the {@code application/x-www-form-urlencoded} request string that can be used to
-     * POST this request to the token endpoint.
-     */
-    @NonNull
-    public String getFormUrlEncodedRequestBody() {
-        Map<String, String> requestParams = getRequestParameters();
-
-        // use android.net.Uri to produce the url-encoded string by adding all
-        // parameters, then requesting the encoded query.
-        Uri.Builder encodingUri = new Uri.Builder();
-        for (Entry<String, String> param : requestParams.entrySet()) {
-            encodingUri.appendQueryParameter(param.getKey(), param.getValue());
-        }
-
-        return encodingUri.build().getEncodedQuery();
     }
 
     /**

--- a/library/java/net/openid/appauth/UriUtil.java
+++ b/library/java/net/openid/appauth/UriUtil.java
@@ -17,6 +17,13 @@ package net.openid.appauth;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Utility methods for extracting parameters from Uri objects.
@@ -55,5 +62,22 @@ class UriUtil {
             return Long.parseLong(valueStr);
         }
         return null;
+    }
+
+    public static String formUrlEncode(Map<String, String> parameters) {
+        if (parameters == null) {
+            return "";
+        }
+
+        List<String> queryParts = new ArrayList<>();
+        for (Map.Entry<String, String> param : parameters.entrySet()) {
+            try {
+                queryParts.add(param.getKey() + "=" + URLEncoder.encode(param.getValue(), "utf-8"));
+            } catch (UnsupportedEncodingException e) {
+                // Should not end up here
+                Logger.error("Could not utf-8 encode.");
+            }
+        }
+        return TextUtils.join("&", queryParts);
     }
 }

--- a/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
+++ b/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.util.Base64;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Map;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ClientSecretBasicTest {
+    @Test
+    public void testGetRequestHeaders() {
+        ClientSecretBasic csb = new ClientSecretBasic(TEST_CLIENT_SECRET);
+
+        Map<String, String> headers = csb.getRequestHeaders(TEST_CLIENT_ID);
+
+        String credentials = TEST_CLIENT_ID + ":" + TEST_CLIENT_SECRET;
+        String authz = Base64.encodeToString(credentials.getBytes(), Base64.NO_WRAP);
+        String expectedAuthzHeader = "Basic " + authz;
+        assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers).containsEntry("Authorization", expectedAuthzHeader);
+    }
+
+    @Test
+    public void testGetRequestParameters() {
+        ClientSecretBasic csb = new ClientSecretBasic(TEST_CLIENT_SECRET);
+        assertThat(csb.getRequestParameters(TEST_CLIENT_ID)).isNull();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructor_withNull() {
+        new ClientSecretBasic(null);
+    }
+}

--- a/library/javatests/net/openid/appauth/ClientSecretPostTest.java
+++ b/library/javatests/net/openid/appauth/ClientSecretPostTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
+import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Map;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ClientSecretPostTest {
+    @Test
+    public void testGetRequestParameters() throws Exception {
+        ClientSecretPost csp = new ClientSecretPost(TEST_CLIENT_SECRET);
+        Map<String, String> parameters = csp.getRequestParameters(TEST_CLIENT_ID);
+        assertThat(parameters).containsEntry(ClientSecretPost.PARAM_CLIENT_ID, TEST_CLIENT_ID);
+        assertThat(parameters).containsEntry(
+                ClientSecretPost.PARAM_CLIENT_SECRET, TEST_CLIENT_SECRET);
+    }
+
+    @Test
+    public void testGetRequestHeaders() throws Exception {
+        ClientSecretPost csp = new ClientSecretPost(TEST_CLIENT_SECRET);
+        assertThat(csp.getRequestHeaders(TEST_CLIENT_ID)).isNull();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructor_withNull() {
+        new ClientSecretPost(null);
+    }
+}

--- a/library/javatests/net/openid/appauth/NoClientAuthenticationTest.java
+++ b/library/javatests/net/openid/appauth/NoClientAuthenticationTest.java
@@ -14,37 +14,32 @@
 
 package net.openid.appauth;
 
-import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
-import static net.openid.appauth.TestValues.TEST_AUTH_CODE;
-import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
-import static net.openid.appauth.TestValues.getTestServiceConfig;
 
-import org.junit.Before;
+import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.Collections;
-
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
-public class TokenResponseTest {
-
-    private TokenResponse.Builder mMinimalBuilder;
-
-    @Before
-    public void setUp() {
-        TokenRequest request = new TokenRequest.Builder(getTestServiceConfig(), TEST_CLIENT_ID)
-                .setAuthorizationCode(TEST_AUTH_CODE)
-                .setRedirectUri(TEST_APP_REDIRECT_URI)
-                .build();
-        mMinimalBuilder = new TokenResponse.Builder(request);
+public class NoClientAuthenticationTest {
+    @Test
+    public void testGetInstance() {
+        assertThat(NoClientAuthentication.INSTANCE)
+                .isSameAs(NoClientAuthentication.INSTANCE);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_setAdditionalParams_withBuiltInParam() {
-        mMinimalBuilder.setAdditionalParameters(
-                Collections.singletonMap(TokenRequest.PARAM_SCOPE, "scope"));
+    @Test
+    public void testGetRequestHeaders() {
+        assertThat(NoClientAuthentication.INSTANCE.getRequestHeaders(TEST_CLIENT_ID)).isNull();
+    }
+
+    @Test
+    public void testGetRequestParameters() {
+        assertThat(NoClientAuthentication.INSTANCE.getRequestParameters(TEST_CLIENT_ID))
+                .isNull();
     }
 }

--- a/library/javatests/net/openid/appauth/RegistrationRequestTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/library/javatests/net/openid/appauth/TokenRequestTest.java
+++ b/library/javatests/net/openid/appauth/TokenRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -117,7 +117,7 @@ public class TokenRequestTest {
     }
 
     @Test
-    public void testToUri_forCodeExchange() {
+    public void testGetRequestParameters_forCodeExchange() {
         TokenRequest request = mAuthorizationCodeRequestBuilder.build();
 
         Map<String, String> params = request.getRequestParameters();
@@ -136,7 +136,7 @@ public class TokenRequestTest {
     }
 
     @Test
-    public void testToUri_forRefreshToken() {
+    public void testGetRequestParameters_forRefreshToken() {
         TokenRequest request = mMinimalBuilder
                 .setRefreshToken(TEST_REFRESH_TOKEN)
                 .build();
@@ -154,7 +154,7 @@ public class TokenRequestTest {
     }
 
     @Test
-    public void testToUri_withCodeVerifier() {
+    public void testGetRequestParameters_withCodeVerifier() {
         TokenRequest request = mAuthorizationCodeRequestBuilder
                 .setCodeVerifier(TEST_CODE_VERIFIER)
                 .build();

--- a/library/javatests/net/openid/appauth/UriUtilTest.java
+++ b/library/javatests/net/openid/appauth/UriUtilTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.net.UrlQuerySanitizer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class UriUtilTest {
+
+    private UrlQuerySanitizer mSanitizer;
+
+    @Before
+    public void setUp() {
+        mSanitizer = new UrlQuerySanitizer();
+        mSanitizer.setAllowUnregisteredParamaters(true);
+        mSanitizer.setUnregisteredParameterValueSanitizer(UrlQuerySanitizer.getUrlAndSpaceLegal());
+    }
+
+    @Test
+    public void testFormUrlEncode() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("test1", "value1");
+        parameters.put("test2", "value2");
+        String query = UriUtil.formUrlEncode(parameters);
+
+        mSanitizer.parseQuery(query);
+        for (Map.Entry<String, String> param : parameters.entrySet()) {
+            assertThat(mSanitizer.getValue(param.getKey())).isEqualTo(param.getValue());
+        }
+    }
+
+    @Test
+    public void testFormUrlEncode_withSpaceSeparatedValueForParameter() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("test1", "value1");
+        parameters.put("test2", "value2 value3");
+        String query = UriUtil.formUrlEncode(parameters);
+
+        assertThat(query.contains("value2+value3"));
+        mSanitizer.parseQuery(query);
+        for (Map.Entry<String, String> param : parameters.entrySet()) {
+            assertThat(mSanitizer.getValue(param.getKey())).isEqualTo(param.getValue());
+        }
+    }
+
+    @Test
+    public void testFormUrlEncode_withNull() {
+        assertThat(UriUtil.formUrlEncode(null)).isEqualTo("");
+    }
+
+    @Test
+    public void testFormUrlEncode_withEmpty() {
+        assertThat(UriUtil.formUrlEncode(new HashMap<String, String>())).isEqualTo("");
+    }
+}


### PR DESCRIPTION
(This branch is based off PR #40, so the relevant diff is [here](https://github.com/rebeckag/AppAuth-Android/compare/oidc-dynreg...rebeckag:client-auth).)

Implementation of 'client_secret_basic' and 'client_secret_post' per [specs](http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication).

What's done:
* Representation for different ClientAuthentication methods.
* Added possibility to specify client authentication in AsyncTask for TokenRequest.
* Example in the demo app of how it could be used.

Still left:
* Documentation/references to the valid sections of the specification.
* Maybe figure out better design for how the client authentication is applied in TokenRequestTask.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/41)
<!-- Reviewable:end -->
