### PR TITLE
Normalize names and documentation of JSON serialization methods

### DIFF
--- a/app/src/net/openid/appauthdemo/TokenActivity.java
+++ b/app/src/net/openid/appauthdemo/TokenActivity.java
@@ -92,7 +92,8 @@ public class TokenActivity extends AppCompatActivity {
         if (savedInstanceState != null) {
             if (savedInstanceState.containsKey(KEY_AUTH_STATE)) {
                 try {
-                    mAuthState = AuthState.fromJson(savedInstanceState.getString(KEY_AUTH_STATE));
+                    mAuthState = AuthState.jsonDeserialize(
+                            savedInstanceState.getString(KEY_AUTH_STATE));
                 } catch (JSONException ex) {
                     Log.e(TAG, "Malformed authorization JSON saved", ex);
                 }
@@ -132,9 +133,8 @@ public class TokenActivity extends AppCompatActivity {
 
     @Override
     protected void onSaveInstanceState(Bundle state) {
-        String authorizationStr = null;
         if (mAuthState != null) {
-            state.putString(KEY_AUTH_STATE, mAuthState.toJsonString());
+            state.putString(KEY_AUTH_STATE, mAuthState.jsonSerializeString());
         }
 
         if (mUserInfoJson != null) {

--- a/library/java/net/openid/appauth/AuthState.java
+++ b/library/java/net/openid/appauth/AuthState.java
@@ -445,9 +445,10 @@ public class AuthState {
     }
 
     /**
-     * Converts the authorization state to a JSON object for storage or transmission.
+     * Produces a JSON representation of the authorization state for persistent storage or local
+     * transmission (e.g. between activities).
      */
-    public JSONObject toJson() {
+    public JSONObject jsonSerialize() {
         JSONObject json = new JSONObject();
         JsonUtil.putIfNotNull(json, KEY_REFRESH_TOKEN, mRefreshToken);
         JsonUtil.putIfNotNull(json, KEY_SCOPE, mScope);
@@ -460,29 +461,32 @@ public class AuthState {
             JsonUtil.put(
                     json,
                     KEY_LAST_AUTHORIZATION_RESPONSE,
-                    mLastAuthorizationResponse.toJson());
+                    mLastAuthorizationResponse.jsonSerialize());
         }
         if (mLastTokenResponse != null) {
             JsonUtil.put(
                     json,
                     KEY_LAST_TOKEN_RESPONSE,
-                    mLastTokenResponse.toJson());
+                    mLastTokenResponse.jsonSerialize());
         }
         return json;
     }
 
     /**
-     * Converts the authorization state to a JSON string for storage or transmission.
+     * Produces a JSON string representation of the authorization state for persistent storage or
+     * local transmission (e.g. between activities). This method is just a convenience wrapper
+     * for {@link #jsonSerialize()}, converting the JSON object to its string form.
      */
-    public String toJsonString() {
-        return toJson().toString();
+    public String jsonSerializeString() {
+        return jsonSerialize().toString();
     }
 
     /**
-     * Restores authorization state from JSON produced by {@link #toJson()}.
-     * @throws JSONException if the JSON is malformed or missing required fields.
+     * Reads an authorization state instance from a JSON string representation produced by
+     * {@link #jsonSerialize()}.
+     * @throws JSONException if the provided JSON does not match the expected structure.
      */
-    public static AuthState fromJson(@NonNull JSONObject json) throws JSONException {
+    public static AuthState jsonDeserialize(@NonNull JSONObject json) throws JSONException {
         checkNotNull(json, "json cannot be null");
 
         AuthState state = new AuthState();
@@ -493,11 +497,11 @@ public class AuthState {
                     json.getJSONObject(KEY_AUTHORIZATION_EXCEPTION));
         }
         if (json.has(KEY_LAST_AUTHORIZATION_RESPONSE)) {
-            state.mLastAuthorizationResponse = AuthorizationResponse.fromJson(
+            state.mLastAuthorizationResponse = AuthorizationResponse.jsonDeserialize(
                     json.getJSONObject(KEY_LAST_AUTHORIZATION_RESPONSE));
         }
         if (json.has(KEY_LAST_TOKEN_RESPONSE)) {
-            state.mLastTokenResponse = TokenResponse.fromJson(
+            state.mLastTokenResponse = TokenResponse.jsonDeserialize(
                     json.getJSONObject(KEY_LAST_TOKEN_RESPONSE));
         }
 
@@ -505,12 +509,14 @@ public class AuthState {
     }
 
     /**
-     * Restored authorization state from a JSON string produced by {@link #toJsonString()}.
-     * @throws JSONException if the JSON is malformed or missing required fields.
+     * Reads an authorization state instance from a JSON string representation produced by
+     * {@link #jsonSerializeString()}. This method is just a convenience wrapper for
+     * {@link #jsonDeserialize(JSONObject)}, converting the JSON string to its JSON object form.
+     * @throws JSONException if the provided JSON does not match the expected structure.
      */
-    public static AuthState fromJson(@NonNull String jsonStr) throws JSONException {
+    public static AuthState jsonDeserialize(@NonNull String jsonStr) throws JSONException {
         checkNotEmpty(jsonStr, "jsonStr cannot be null or empty");
-        return fromJson(new JSONObject(jsonStr));
+        return jsonDeserialize(new JSONObject(jsonStr));
     }
 
     /**

--- a/library/java/net/openid/appauth/AuthorizationRequest.java
+++ b/library/java/net/openid/appauth/AuthorizationRequest.java
@@ -874,10 +874,11 @@ public class AuthorizationRequest {
     }
 
     /**
-     * Produces a JSON representation of the request for storage or transmission.
+     * Produces a JSON representation of the authorization request for persistent storage or local
+     * transmission (e.g. between activities).
      */
     @NonNull
-    public JSONObject toJson() {
+    public JSONObject jsonSerialize() {
         JSONObject json = new JSONObject();
         JsonUtil.put(json, KEY_CONFIGURATION, configuration.toJson());
         JsonUtil.put(json, KEY_CLIENT_ID, clientId);
@@ -885,6 +886,7 @@ public class AuthorizationRequest {
         JsonUtil.put(json, KEY_REDIRECT_URI, redirectUri.toString());
         JsonUtil.putIfNotNull(json, KEY_DISPLAY, display);
         JsonUtil.putIfNotNull(json, KEY_SCOPE, scope);
+        JsonUtil.putIfNotNull(json, KEY_PROMPT, prompt);
         JsonUtil.putIfNotNull(json, KEY_STATE, state);
         JsonUtil.putIfNotNull(json, KEY_CODE_VERIFIER, codeVerifier);
         JsonUtil.putIfNotNull(json, KEY_CODE_VERIFIER_CHALLENGE, codeVerifierChallenge);
@@ -897,30 +899,22 @@ public class AuthorizationRequest {
     }
 
     /**
-     * Produces a JSON string representation of the request for storage or transmission.
+     * Produces a JSON string representation of the authorization request for persistent storage or
+     * local transmission (e.g. between activities). This method is just a convenience wrapper
+     * for {@link #jsonSerialize()}, converting the JSON object to its string form.
      */
-    public String toJsonString() {
-        return toJson().toString();
+    public String jsonSerializeString() {
+        return jsonSerialize().toString();
     }
 
     /**
-     * Reads an Authorization request from a JSON string representation produced by
-     * {@link #toJsonString()}.
+     * Reads an authorization request from a JSON string representation produced by
+     * {@link #jsonSerialize()}.
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
     @NonNull
-    public static AuthorizationRequest fromJson(@NonNull String jsonStr) throws JSONException {
-        checkNotNull(jsonStr, "json string cannot be null");
-        return fromJson(new JSONObject(jsonStr));
-    }
-
-    /**
-     * Reads an Authorization request from a JSON representation produced by
-     * {@link #toJson()}.
-     * @throws JSONException if the provided JSON does not match the expected structure.
-     */
-    @NonNull
-    public static AuthorizationRequest fromJson(@NonNull JSONObject json) throws JSONException {
+    public static AuthorizationRequest jsonDeserialize(@NonNull JSONObject json)
+            throws JSONException {
         checkNotNull(json, "json cannot be null");
         AuthorizationRequest.Builder builder = new AuthorizationRequest.Builder(
                 AuthorizationServiceConfiguration.fromJson(json.getJSONObject(KEY_CONFIGURATION)),
@@ -940,6 +934,19 @@ public class AuthorizationRequest {
             builder.setScopes(AsciiStringListUtil.stringToSet(JsonUtil.getString(json, KEY_SCOPE)));
         }
         return builder.build();
+    }
+
+    /**
+     * Reads an authorization request from a JSON string representation produced by
+     * {@link #jsonSerializeString()}. This method is just a convenience wrapper for
+     * {@link #jsonDeserialize(JSONObject)}, converting the JSON string to its JSON object form.
+     * @throws JSONException if the provided JSON does not match the expected structure.
+     */
+    @NonNull
+    public static AuthorizationRequest jsonDeserialize(@NonNull String jsonStr)
+            throws JSONException {
+        checkNotNull(jsonStr, "json string cannot be null");
+        return jsonDeserialize(new JSONObject(jsonStr));
     }
 
     private static String generateRandomState() {

--- a/library/java/net/openid/appauth/TokenRequest.java
+++ b/library/java/net/openid/appauth/TokenRequest.java
@@ -519,10 +519,11 @@ public class TokenRequest {
     }
 
     /**
-     * Converts the token request to JSON for storage or transmission.
+     * Produces a JSON string representation of the token request for persistent storage or
+     * local transmission (e.g. between activities).
      */
     @NonNull
-    public JSONObject toJson() {
+    public JSONObject jsonSerialize() {
         JSONObject json = new JSONObject();
         JsonUtil.put(json, KEY_CONFIGURATION, configuration.toJson());
         JsonUtil.put(json, KEY_CLIENT_ID, clientId);
@@ -537,33 +538,22 @@ public class TokenRequest {
     }
 
     /**
-     * Converts the authorization request to a JSON string for storage or transmission.
+     * Produces a JSON string representation of the token request for persistent storage or
+     * local transmission (e.g. between activities). This method is just a convenience wrapper
+     * for {@link #jsonSerialize()}, converting the JSON object to its string form.
      */
     @NonNull
-    public String toJsonString() {
-        return toJson().toString();
+    public String jsonSerializeString() {
+        return jsonSerialize().toString();
     }
 
     /**
-     * Reads a token request from a JSON string representation produced by the
-     * {@link #toJson()} method or some other equivalent producer.
-     *
+     * Reads a token request from a JSON string representation produced by
+     * {@link #jsonSerialize()}.
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
     @NonNull
-    public static TokenRequest fromJson(@NonNull String json) throws JSONException {
-        checkNotNull(json, "json string cannot be null");
-        return fromJson(new JSONObject(json));
-    }
-
-    /**
-     * Reads a token request from a JSON representation produced by the
-     * {@link #toJson()} method or some other equivalent producer.
-     *
-     * @throws JSONException if the provided JSON does not match the expected structure.
-     */
-    @NonNull
-    public static TokenRequest fromJson(JSONObject json) throws JSONException {
+    public static TokenRequest jsonDeserialize(JSONObject json) throws JSONException {
         checkNotNull(json, "json object cannot be null");
 
         TokenRequest.Builder builder = new TokenRequest.Builder(
@@ -580,5 +570,17 @@ public class TokenRequest {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Reads a token request from a JSON string representation produced by
+     * {@link #jsonSerializeString()}. This method is just a convenience wrapper for
+     * {@link #jsonDeserialize(JSONObject)}, converting the JSON string to its JSON object form.
+     * @throws JSONException if the provided JSON does not match the expected structure.
+     */
+    @NonNull
+    public static TokenRequest jsonDeserialize(@NonNull String json) throws JSONException {
+        checkNotNull(json, "json string cannot be null");
+        return jsonDeserialize(new JSONObject(json));
     }
 }

--- a/library/javatests/net/openid/appauth/AuthStateTest.java
+++ b/library/javatests/net/openid/appauth/AuthStateTest.java
@@ -504,8 +504,8 @@ public class AuthStateTest {
         TokenResponse tokenResp = getTestAuthCodeExchangeResponse();
         AuthState state = new AuthState(authResp, tokenResp, null);
 
-        String json = state.toJsonString();
-        AuthState restoredState = AuthState.fromJson(json);
+        String json = state.jsonSerializeString();
+        AuthState restoredState = AuthState.jsonDeserialize(json);
 
         assertThat(restoredState.isAuthorized()).isEqualTo(state.isAuthorized());
 
@@ -525,7 +525,7 @@ public class AuthStateTest {
                 null,
                 AuthorizationException.AuthorizationRequestErrors.INVALID_REQUEST);
 
-        AuthState restored = AuthState.fromJson(state.toJsonString());
+        AuthState restored = AuthState.jsonDeserialize(state.jsonSerializeString());
         assertThat(restored.getAuthorizationException())
                 .isEqualTo(state.getAuthorizationException());
     }

--- a/library/javatests/net/openid/appauth/AuthorizationRequestTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationRequestTest.java
@@ -419,7 +419,8 @@ public class AuthorizationRequestTest {
 
     @Test
     public void testSerialization() throws Exception {
-        AuthorizationRequest request = AuthorizationRequest.fromJson(mRequest.toJson());
+        AuthorizationRequest request =
+                AuthorizationRequest.jsonDeserialize(mRequest.jsonSerialize());
         assertValues(request);
     }
 
@@ -428,7 +429,8 @@ public class AuthorizationRequestTest {
         AuthorizationRequest request = mRequestBuilder
                 .setScopes((Iterable<String>)null)
                 .build();
-        AuthorizationRequest newRequest = AuthorizationRequest.fromJson(request.toJson());
+        AuthorizationRequest newRequest =
+                AuthorizationRequest.jsonDeserialize(request.jsonSerialize());
         assertNull(newRequest.scope);
     }
 
@@ -437,7 +439,8 @@ public class AuthorizationRequestTest {
         AuthorizationRequest request = mRequestBuilder
                 .setScopes(Collections.<String>emptyList())
                 .build();
-        AuthorizationRequest newRequest = AuthorizationRequest.fromJson(request.toJson());
+        AuthorizationRequest newRequest =
+                AuthorizationRequest.jsonDeserialize(request.jsonSerialize());
         assertNull(newRequest.scope);
     }
 

--- a/library/javatests/net/openid/appauth/AuthorizationResponseTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationResponseTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 
 import android.net.Uri;
 
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -118,8 +117,8 @@ public class AuthorizationResponseTest {
 
     @Test
     public void testSerialization() throws Exception {
-        JSONObject json = mAuthorizationResponse.toJson();
-        AuthorizationResponse authResponse = AuthorizationResponse.fromJson(json);
+        String json = mAuthorizationResponse.jsonSerializeString();
+        AuthorizationResponse authResponse = AuthorizationResponse.jsonDeserialize(json);
         checkExpectedFields(authResponse);
     }
 

--- a/library/javatests/net/openid/appauth/RegistrationRequestTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationRequestTest.java
@@ -137,7 +137,7 @@ public class RegistrationRequestTest {
     @Test
     public void testSerialize() throws JSONException {
         RegistrationRequest request = mMaximalRequestBuilder.build();
-        JSONObject json = request.serialize();
+        JSONObject json = request.jsonSerialize();
         assertMaximalValuesInJson(request, json);
         assertThat(json.getJSONObject(RegistrationRequest.KEY_CONFIGURATION).toString())
                 .isEqualTo(request.configuration.toJson().toString());
@@ -148,7 +148,7 @@ public class RegistrationRequestTest {
         Map<String, String> additionalParameters = Collections.singletonMap("test1", "value1");
         RegistrationRequest request = mMaximalRequestBuilder
                 .setAdditionalParameters(additionalParameters).build();
-        JSONObject json = request.serialize();
+        JSONObject json = request.jsonSerialize();
         assertMaximalValuesInJson(request, json);
         assertThat(JsonUtil.getStringMap(json, RegistrationRequest.KEY_ADDITIONAL_PARAMETERS))
                 .isEqualTo(additionalParameters);
@@ -157,7 +157,7 @@ public class RegistrationRequestTest {
     @Test
     public void testDeserialize() throws JSONException {
         mJson.put(RegistrationRequest.KEY_CONFIGURATION, getTestServiceConfig().toJson());
-        RegistrationRequest request = RegistrationRequest.deserialize(mJson);
+        RegistrationRequest request = RegistrationRequest.jsonDeserialize(mJson);
         assertThat(request.configuration.toJsonString())
                 .isEqualTo(getTestServiceConfig().toJsonString());
         assertMaximalValuesInJson(request, mJson);
@@ -171,7 +171,7 @@ public class RegistrationRequestTest {
         additionalParameters.put("key2", "value2");
         mJson.put(RegistrationRequest.KEY_ADDITIONAL_PARAMETERS,
                 JsonUtil.mapToJsonObject(additionalParameters));
-        RegistrationRequest request = RegistrationRequest.deserialize(mJson);
+        RegistrationRequest request = RegistrationRequest.jsonDeserialize(mJson);
         assertThat(request.additionalParameters).isEqualTo(additionalParameters);
     }
 
@@ -187,7 +187,7 @@ public class RegistrationRequestTest {
         assertThat(json.get(RegistrationRequest.PARAM_REDIRECT_URIS))
                 .isEqualTo(JsonUtil.toJsonArray(request.redirectUris));
         assertThat(json.get(RegistrationRequest.PARAM_APPLICATION_TYPE))
-                .isEqualTo(request.APPLICATION_TYPE_NATIVE);
+                .isEqualTo(RegistrationRequest.APPLICATION_TYPE_NATIVE);
         assertThat(json.get(RegistrationRequest.PARAM_RESPONSE_TYPES))
                 .isEqualTo(JsonUtil.toJsonArray(request.responseTypes));
         assertThat(json.get(RegistrationRequest.PARAM_GRANT_TYPES))

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -87,10 +87,10 @@ public class RegistrationResponseTest {
         @Test
         public void testSerialize() throws Exception {
             JSONObject json = RegistrationResponse.fromJson(getTestRegistrationRequest(), mJson)
-                    .serialize();
+                    .jsonSerialize();
 
             assertThat(json.get(RegistrationResponse.KEY_REQUEST).toString())
-                    .isEqualTo(getTestRegistrationRequest().serialize().toString());
+                    .isEqualTo(getTestRegistrationRequest().jsonSerialize().toString());
             assertThat(json.getLong(RegistrationResponse.PARAM_CLIENT_ID_ISSUED_AT))
                     .isEqualTo(TEST_CLIENT_ID_ISSUED_AT);
             assertThat(json.getString(RegistrationResponse.PARAM_CLIENT_SECRET))
@@ -108,20 +108,22 @@ public class RegistrationResponseTest {
             Map<String, String> additionalParameters = Collections.singletonMap("test1", "value1");
             JSONObject json = mMinimalBuilder.setClientId(TEST_CLIENT_ID)
                     .setAdditionalParameters(additionalParameters)
-                    .build().serialize();
+                    .build()
+                    .jsonSerialize();
             assertThat(JsonUtil.getStringMap(json, RegistrationResponse.KEY_ADDITIONAL_PARAMETERS))
                     .isEqualTo(additionalParameters);
         }
 
         @Test(expected = IllegalArgumentException.class)
         public void testDeserialize_withoutRequest() throws Exception {
-            RegistrationResponse.deserialize(mJson);
+            RegistrationResponse.jsonDeserialize(mJson);
         }
 
         @Test
         public void testDeserialize() throws Exception {
-            mJson.put(RegistrationResponse.KEY_REQUEST, getTestRegistrationRequest().serialize());
-            RegistrationResponse response = RegistrationResponse.deserialize(mJson);
+            mJson.put(RegistrationResponse.KEY_REQUEST,
+                    getTestRegistrationRequest().jsonSerialize());
+            RegistrationResponse response = RegistrationResponse.jsonDeserialize(mJson);
             assertValues(response);
         }
 


### PR DESCRIPTION
Suggestion by @rebeckag, to clarify which methods are specifically for local serialization vs the JSON formats that are part of the spec for transmission to / reception from authorization servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/53)
<!-- Reviewable:end -->
