### PR TITLE
Remove build version hack required for older android gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,11 +101,6 @@ task doFirst {
 }
 
 buildscript {
-    // workaround for the Android plugin thinking that gradle 2.11 is less
-    // up-to-date than gradle 2.2:
-    // https://discuss.gradle.org/t/gradle-thinks-2-10-is-less-than-2-2-when-resolving-plugins
-    System.properties['com.android.build.gradle.overrideVersionCheck'] = 'true'
-
     repositories {
         jcenter()
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/54)
<!-- Reviewable:end -->
