### PR TITLE
Split AuthorizationRequest tests into smaller units

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationRequest.java
+++ b/library/java/net/openid/appauth/AuthorizationRequest.java
@@ -123,6 +123,9 @@ public class AuthorizationRequest {
      * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">"OpenID
      * Connect Core 1.0", Section 3.1.2.1</a>
      */
+    // SuppressWarnings justification: the constants defined are not directly used by the library,
+    // existing only for convenience of the developer.
+    @SuppressWarnings("unused")
     public static final class Display {
 
         /**
@@ -159,6 +162,9 @@ public class AuthorizationRequest {
      * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">"OpenID
      * Connect Core 1.0", Section 3.1.2.1</a>
      */
+    // SuppressWarnings justification: the constants defined are not directly used by the library,
+    // existing only for convenience of the developer.
+    @SuppressWarnings("unused")
     public static final class Prompt {
 
         /**
@@ -434,10 +440,16 @@ public class AuthorizationRequest {
      */
     public static final class Builder {
 
+        // SuppressWarnings justification: static analysis incorrectly determines that this field
+        // is not initialized, as it is indirectly initialized by setConfiguration
         @NonNull
+        @SuppressWarnings("NullableProblems")
         private AuthorizationServiceConfiguration mConfiguration;
 
+        // SuppressWarnings justification: static analysis incorrectly determines that this field
+        // is not initialized, as it is indirectly initialized by setClientId
         @NonNull
+        @SuppressWarnings("NullableProblems")
         private String mClientId;
 
         @Nullable
@@ -446,10 +458,16 @@ public class AuthorizationRequest {
         @Nullable
         private String mPrompt;
 
+        // SuppressWarnings justification: static analysis incorrectly determines that this field
+        // is not initialized, as it is indirectly initialized by setResponseType
         @NonNull
+        @SuppressWarnings("NullableProblems")
         private String mResponseType;
 
+        // SuppressWarnings justification: static analysis incorrectly determines that this field
+        // is not initialized, as it is indirectly initialized by setRedirectUri
         @NonNull
+        @SuppressWarnings("NullableProblems")
         private Uri mRedirectUri;
 
         @Nullable
@@ -510,8 +528,7 @@ public class AuthorizationRequest {
          */
         @NonNull
         public Builder setClientId(@NonNull String clientId) {
-            checkArgument(!TextUtils.isEmpty(clientId), "client ID cannot be null or empty");
-            mClientId = clientId;
+            mClientId = checkNotEmpty(clientId, "client ID cannot be null or empty");
             return this;
         }
 
@@ -537,7 +554,7 @@ public class AuthorizationRequest {
          */
         @NonNull
         public Builder setPrompt(@Nullable String prompt) {
-            mPrompt = Preconditions.checkNullOrNotEmpty(prompt, "prompt must be null or non-empty");
+            mPrompt = checkNullOrNotEmpty(prompt, "prompt must be null or non-empty");
             return this;
         }
 
@@ -587,9 +604,8 @@ public class AuthorizationRequest {
          */
         @NonNull
         public Builder setResponseType(@NonNull String responseType) {
-            checkArgument(!TextUtils.isEmpty(responseType),
+            mResponseType = checkNotEmpty(responseType,
                     "expected response type cannot be null or empty");
-            mResponseType = responseType;
             return this;
         }
 
@@ -671,11 +687,7 @@ public class AuthorizationRequest {
          */
         @NonNull
         public Builder setState(@Nullable String state) {
-            if (state != null) {
-                checkArgument(!TextUtils.isEmpty(state),
-                        "state cannot be empty if defined");
-            }
-            mState = state;
+            mState = checkNullOrNotEmpty(state, "state cannot be empty if defined");
             return this;
         }
 
@@ -922,6 +934,7 @@ public class AuthorizationRequest {
                 JsonUtil.getString(json, KEY_RESPONSE_TYPE),
                 JsonUtil.getUri(json, KEY_REDIRECT_URI))
                 .setDisplay(JsonUtil.getStringIfDefined(json, KEY_DISPLAY))
+                .setPrompt(JsonUtil.getStringIfDefined(json, KEY_PROMPT))
                 .setState(JsonUtil.getStringIfDefined(json, KEY_STATE))
                 .setCodeVerifier(
                         JsonUtil.getStringIfDefined(json, KEY_CODE_VERIFIER),

--- a/library/java/net/openid/appauth/Preconditions.java
+++ b/library/java/net/openid/appauth/Preconditions.java
@@ -60,6 +60,9 @@ final class Preconditions {
      */
     @NonNull
     public static String checkNotEmpty(String str, @Nullable Object errorMessage) {
+        // ensure that we throw NullPointerException if the value is null, otherwise,
+        // IllegalArgumentException if it is empty
+        checkNotNull(str, errorMessage);
         checkArgument(!TextUtils.isEmpty(str), errorMessage);
         return str;
     }

--- a/library/javatests/net/openid/appauth/AuthorizationRequestTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationRequestTest.java
@@ -19,18 +19,16 @@ import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
 import static net.openid.appauth.TestValues.TEST_STATE;
 import static net.openid.appauth.TestValues.getTestServiceConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import android.net.Uri;
 
+import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,9 +46,6 @@ public class AuthorizationRequestTest {
     private static final String TEST_CODE_VERIFIER =
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_~.";
 
-    private static final String TEST_CODE_VERIFIER_CHALLENGE_METHOD =
-            "plain";
-
     private static final Map<String, String> TEST_ADDITIONAL_PARAMS;
 
     static {
@@ -60,96 +55,146 @@ public class AuthorizationRequestTest {
     }
 
     private AuthorizationRequest.Builder mRequestBuilder;
-    private AuthorizationRequest mRequest;
-
-    private AuthorizationRequest.Builder mMinimalRequestBuilder;
 
     @Before
     public void setUp() {
-
-        mMinimalRequestBuilder = new AuthorizationRequest.Builder(
-                getTestServiceConfig(),
-                TEST_CLIENT_ID,
-                ResponseTypeValues.CODE,
-                TEST_APP_REDIRECT_URI);
-
         mRequestBuilder = new AuthorizationRequest.Builder(
                 getTestServiceConfig(),
                 TEST_CLIENT_ID,
                 ResponseTypeValues.CODE,
-                TEST_APP_REDIRECT_URI)
-                .setState(TEST_STATE)
-                .setScopes(AuthorizationRequest.SCOPE_OPENID, AuthorizationRequest.SCOPE_EMAIL)
-                .setCodeVerifier(
-                        TEST_CODE_VERIFIER,
-                        TEST_CODE_VERIFIER,
-                        TEST_CODE_VERIFIER_CHALLENGE_METHOD)
-                .setResponseMode(AuthorizationRequest.RESPONSE_MODE_QUERY)
-                .setAdditionalParameters(TEST_ADDITIONAL_PARAMS);
-        mRequest = mRequestBuilder.build();
+                TEST_APP_REDIRECT_URI);
     }
 
-    @Test
-    public void testBuilder() {
-        assertValues(mRequest);
+    /* ********************************** Builder() ***********************************************/
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    public void testBuilder_nullConfiguration() {
+        new AuthorizationRequest.Builder(
+                null,
+                TEST_CLIENT_ID,
+                ResponseTypeValues.CODE,
+                TEST_APP_REDIRECT_URI);
+    }
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    public void testBuilder_nullClientId() {
+        new AuthorizationRequest.Builder(
+                getTestServiceConfig(),
+                null,
+                ResponseTypeValues.CODE,
+                TEST_APP_REDIRECT_URI);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_codeVerifierTooShort() {
-        // code verifier is one character too short
-        char[] codeVerifier = new char[CodeVerifierUtil.MIN_CODE_VERIFIER_LENGTH - 1];
-        for (int i = 0; i < codeVerifier.length; i++) {
-            codeVerifier[i] = '0';
-        }
-        AuthorizationRequest request = new AuthorizationRequest.Builder(
+    public void testBuilder_emptyClientId() {
+        new AuthorizationRequest.Builder(
+                getTestServiceConfig(),
+                "",
+                ResponseTypeValues.CODE,
+                TEST_APP_REDIRECT_URI);
+    }
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    public void testBuilder_nullResponseType() {
+        new AuthorizationRequest.Builder(
+                getTestServiceConfig(),
+                TEST_CLIENT_ID,
+                null,
+                TEST_APP_REDIRECT_URI);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_emptyResponseType() {
+        new AuthorizationRequest.Builder(
+                getTestServiceConfig(),
+                TEST_CLIENT_ID,
+                "",
+                TEST_APP_REDIRECT_URI);
+    }
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    public void testBuilder_nullRedirectUri() {
+        new AuthorizationRequest.Builder(
                 getTestServiceConfig(),
                 TEST_CLIENT_ID,
                 ResponseTypeValues.CODE,
-                TEST_APP_REDIRECT_URI)
-                .setCodeVerifier(new String(codeVerifier))
+                null);
+    }
+
+    /* ************************************** clientId ********************************************/
+
+    @Test
+    public void testClientId_fromConstructor() {
+        AuthorizationRequest request = mRequestBuilder.build();
+        assertThat(request.clientId).isEqualTo(TEST_CLIENT_ID);
+    }
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    public void testClientId_null() {
+        mRequestBuilder.setClientId(null).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testClientId_empty() {
+        mRequestBuilder.setClientId("").build();
+    }
+
+    /* ************************************** codeVerifier ****************************************/
+
+    @Test
+    public void testCodeVerifier_autoGenerated() {
+        AuthorizationRequest request = mRequestBuilder.build();
+        assertThat(request.codeVerifier).isNotEmpty();
+        assertThat(request.codeVerifierChallenge).isNotEmpty();
+        assertThat(request.codeVerifierChallengeMethod).isNotEmpty();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCodeVerifier_tooShort() {
+        mRequestBuilder
+                .setCodeVerifier(generateString(CodeVerifierUtil.MIN_CODE_VERIFIER_LENGTH - 1))
                 .build();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_codeVerifierTooLong() {
-        // code verifier is one character too long
-        char[] codeVerifier = new char[CodeVerifierUtil.MAX_CODE_VERIFIER_LENGTH + 1];
-        for (int i = 0; i < codeVerifier.length; i++) {
-            codeVerifier[i] = '0';
-        }
-        AuthorizationRequest request = mRequestBuilder.setCodeVerifier(new String(codeVerifier))
+    public void testCodeVerifier_tooLong() {
+        mRequestBuilder
+                .setCodeVerifier(generateString(CodeVerifierUtil.MAX_CODE_VERIFIER_LENGTH + 1))
                 .build();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_codeVerifierWithIllegalChars() {
-        AuthorizationRequest request = mRequestBuilder
-                .setCodeVerifier("##ILLEGAL!$!")
-                .build();
+    public void testCodeVerifier_illegalChars() {
+        mRequestBuilder.setCodeVerifier("##ILLEGAL!$!").build();
     }
 
     @Test
-    public void testBuilder_disableCodeVerifier() {
+    public void testCodeVerifier_disabled() {
         AuthorizationRequest request = mRequestBuilder
                 .setCodeVerifier(null)
                 .build();
-        assertNull(request.codeVerifier);
-        assertNull(request.codeVerifierChallenge);
-        assertNull(request.codeVerifierChallengeMethod);
+        assertThat(request.codeVerifier).isNull();
+        assertThat(request.codeVerifierChallenge).isNull();
+        assertThat(request.codeVerifierChallengeMethod).isNull();
     }
 
     @Test
-    public void testBuilder_customCodeVerifier() {
+    public void testCodeVerifier_customized() {
         AuthorizationRequest request = mRequestBuilder
                 .setCodeVerifier(TEST_CODE_VERIFIER, "myChallenge", "myChallengeMethod")
                 .build();
-        assertEquals(TEST_CODE_VERIFIER, request.codeVerifier);
-        assertEquals("myChallenge", request.codeVerifierChallenge);
-        assertEquals("myChallengeMethod", request.codeVerifierChallengeMethod);
+        assertThat(request.codeVerifier).isEqualTo(TEST_CODE_VERIFIER);
+        assertThat(request.codeVerifierChallenge).isEqualTo("myChallenge");
+        assertThat(request.codeVerifierChallengeMethod).isEqualTo("myChallengeMethod");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_codeVerifierWithoutCodeChallenge() {
+    @Test(expected = NullPointerException.class)
+    public void testCodeVerifier_withoutCodeChallenge() {
         mRequestBuilder
                 .setCodeVerifier(
                         TEST_CODE_VERIFIER,
@@ -158,46 +203,35 @@ public class AuthorizationRequestTest {
                 .build();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_codeVerifierWithoutCodeChallengeMethod() {
-        String codeVerifier = CodeVerifierUtil.generateRandomCodeVerifier();
+    @Test(expected = NullPointerException.class)
+    public void testCodeVerifier_withoutCodeChallengeMethod() {
         mRequestBuilder
                 .setCodeVerifier(
                         TEST_CODE_VERIFIER,
                         CodeVerifierUtil.deriveCodeVerifierChallenge(TEST_CODE_VERIFIER),
-                        null);
+                        null)
+                .build();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_emptyResponseMode() {
-        mRequestBuilder.setResponseMode("");
-    }
+    /* ************************************** display *********************************************/
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testBuilder_setAdditionalParams_withBuiltInParam() {
-        Map<String, String> additionalParams = new HashMap<>();
-        additionalParams.put(AuthorizationRequest.PARAM_SCOPE, AuthorizationRequest.SCOPE_EMAIL);
-        mRequestBuilder.setAdditionalParameters(additionalParams);
+    @Test
+    public void testDisplay_unspecified() {
+        AuthorizationRequest request = mRequestBuilder.build();
+        assertThat(request.display).isNull();
     }
 
     @Test
     public void testDisplay() {
-        AuthorizationRequest req = mMinimalRequestBuilder
+        AuthorizationRequest req = mRequestBuilder
                 .setDisplay(AuthorizationRequest.Display.TOUCH)
                 .build();
-
         assertThat(req.display).isEqualTo(AuthorizationRequest.Display.TOUCH);
     }
 
     @Test
-    public void testDisplay_isNullByDefault() {
-        AuthorizationRequest req = mMinimalRequestBuilder.build();
-        assertThat(req.display).isNull();
-    }
-
-    @Test
-     public void testDisplay_withNullValue() {
-        AuthorizationRequest req = mMinimalRequestBuilder
+    public void testDisplay_withNullValue() {
+        AuthorizationRequest req = mRequestBuilder
                 .setDisplay(null)
                 .build();
 
@@ -206,41 +240,45 @@ public class AuthorizationRequestTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testDisplay_withEmptyValue() {
-        mMinimalRequestBuilder.setDisplay("").build();
+        mRequestBuilder.setDisplay("").build();
+    }
+
+    /* ************************************** prompt **********************************************/
+
+    @Test
+    public void testPrompt_unspecified() {
+        AuthorizationRequest request = mRequestBuilder.build();
+        assertThat(request.prompt).isNull();
+        assertThat(request.getPromptValues()).isNull();
     }
 
     @Test
     public void testPrompt() {
-        AuthorizationRequest req = mMinimalRequestBuilder
+        AuthorizationRequest req = mRequestBuilder
                 .setPrompt(AuthorizationRequest.Prompt.LOGIN)
                 .build();
 
         assertThat(req.prompt).isEqualTo(AuthorizationRequest.Prompt.LOGIN);
+        assertThat(req.getPromptValues())
+                .hasSize(1)
+                .contains(AuthorizationRequest.Prompt.LOGIN);
     }
 
     @Test
-    public void testPrompt_isNullByDefault() {
-        AuthorizationRequest req = mMinimalRequestBuilder.build();
+    public void testPrompt_nullValue() {
+        AuthorizationRequest req = mRequestBuilder.setPrompt(null).build();
         assertThat(req.prompt).isNull();
-    }
-
-    @Test
-    public void testPrompt_withNullValue() {
-        AuthorizationRequest req = mMinimalRequestBuilder
-                .setPrompt(null)
-                .build();
-
-        assertThat(req.prompt).isNull();
+        assertThat(req.getPromptValues()).isNull();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testPrompt_withEmptyString() {
-        mMinimalRequestBuilder.setPrompt("");
+    public void testPrompt_empty() {
+        mRequestBuilder.setPrompt("").build();
     }
 
     @Test
     public void testPrompt_withVarargs() {
-        AuthorizationRequest req = mMinimalRequestBuilder
+        AuthorizationRequest req = mRequestBuilder
                 .setPromptValues(
                         AuthorizationRequest.Prompt.LOGIN,
                         AuthorizationRequest.Prompt.CONSENT)
@@ -248,112 +286,138 @@ public class AuthorizationRequestTest {
 
         assertThat(req.prompt).isEqualTo(
                 AuthorizationRequest.Prompt.LOGIN + " " + AuthorizationRequest.Prompt.CONSENT);
+        assertThat(req.getPromptValues())
+                .hasSize(2)
+                .contains(AuthorizationRequest.Prompt.LOGIN)
+                .contains(AuthorizationRequest.Prompt.CONSENT);
     }
 
     @Test
     public void testPrompt_withNullVarargsArray() {
-        AuthorizationRequest req = mMinimalRequestBuilder
-                .setPromptValues((String[])null)
-                .build();
-
+        AuthorizationRequest req = mRequestBuilder.setPromptValues((String[])null).build();
         assertThat(req.prompt).isNull();
+        assertThat(req.getPromptValues()).isNull();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPrompt_withNullStringInVarargs() {
-        mMinimalRequestBuilder.setPromptValues(AuthorizationRequest.Prompt.LOGIN, null).build();
+        mRequestBuilder.setPromptValues(AuthorizationRequest.Prompt.LOGIN, null).build();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPrompt_withEmptyStringInVarargs() {
-        mMinimalRequestBuilder.setPromptValues(AuthorizationRequest.Prompt.LOGIN, "").build();
+        mRequestBuilder.setPromptValues(AuthorizationRequest.Prompt.LOGIN, "").build();
     }
 
     @Test
     public void testPrompt_withIterable() {
-        ArrayList<String> promptValues = new ArrayList<>();
-        promptValues.add(AuthorizationRequest.Prompt.SELECT_ACCOUNT);
-        promptValues.add(AuthorizationRequest.Prompt.CONSENT);
-        AuthorizationRequest req = mMinimalRequestBuilder
-                .setPromptValues(promptValues)
+        AuthorizationRequest req = mRequestBuilder
+                .setPromptValues(Arrays.asList(
+                        AuthorizationRequest.Prompt.SELECT_ACCOUNT,
+                        AuthorizationRequest.Prompt.CONSENT))
                 .build();
 
         assertThat(req.prompt).isEqualTo(
-                AuthorizationRequest.Prompt.SELECT_ACCOUNT + " "
+                AuthorizationRequest.Prompt.SELECT_ACCOUNT
+                        + " "
                         + AuthorizationRequest.Prompt.CONSENT);
+
+        assertThat(req.getPromptValues())
+                .hasSize(2)
+                .contains(AuthorizationRequest.Prompt.SELECT_ACCOUNT)
+                .contains(AuthorizationRequest.Prompt.CONSENT);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPrompt_withIterableContainingNullValue() {
-        ArrayList<String> promptValues = new ArrayList<>();
-        promptValues.add(AuthorizationRequest.Prompt.SELECT_ACCOUNT);
-        promptValues.add(null);
-        mMinimalRequestBuilder.setPromptValues(promptValues).build();
+        mRequestBuilder
+                .setPromptValues(Arrays.asList(
+                        AuthorizationRequest.Prompt.SELECT_ACCOUNT,
+                        null))
+                .build();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPrompt_withIterableContainingEmptyValue() {
-        ArrayList<String> promptValues = new ArrayList<>();
-        promptValues.add(AuthorizationRequest.Prompt.SELECT_ACCOUNT);
-        promptValues.add("");
-        mMinimalRequestBuilder.setPromptValues(promptValues).build();
+        mRequestBuilder
+                .setPromptValues(Arrays.asList(
+                        AuthorizationRequest.Prompt.SELECT_ACCOUNT,
+                        ""))
+                .build();
     }
 
+    /* ******************************** redirectUri ***********************************************/
+
     @Test
-    public void testScopes_null() {
+    public void testRedirectUri_fromConstructor() {
+        AuthorizationRequest request = mRequestBuilder.build();
+        assertThat(request.redirectUri).isEqualTo(TEST_APP_REDIRECT_URI);
+    }
+
+    /* ******************************* responseMode ***********************************************/
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_emptyResponseMode() {
+        mRequestBuilder.setResponseMode("").build();
+    }
+
+    /* ******************************* responseType ***********************************************/
+
+    @Test
+    public void testResponseType() {
+        AuthorizationRequest request = mRequestBuilder.build();
+        assertThat(request.responseType).isEqualTo(ResponseTypeValues.CODE);
+    }
+
+    /* *********************************** scope **************************************************/
+
+    @Test
+    public void testScope_null() {
         AuthorizationRequest request = mRequestBuilder
                 .setScopes((Iterable<String>)null)
                 .build();
-        assertNull(request.scope);
+        assertThat(request.scope).isNull();
     }
 
     @Test
-    public void testScopes_empty() {
+    public void testScope_empty() {
         AuthorizationRequest request = mRequestBuilder
                 .setScopes()
                 .build();
-        assertNull(request.scope);
+        assertThat(request.scope).isNull();
     }
 
     @Test
-    public void testScopes_emptyList() {
+    public void testScope_emptyList() {
         AuthorizationRequest request = mRequestBuilder
                 .setScopes(Collections.<String>emptyList())
                 .build();
-        assertNull(request.scope);
+        assertThat(request.scope).isNull();
     }
+
+    /* *********************************** state **************************************************/
+
+    @Test
+    public void testState_autoGenerated() {
+        AuthorizationRequest request = mRequestBuilder.build();
+        assertThat(request.state).isNotEmpty();
+    }
+
+    /* ******************************* additionalParams *******************************************/
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_setAdditionalParams_withBuiltInParam() {
+        Map<String, String> additionalParams = new HashMap<>();
+        additionalParams.put(AuthorizationRequest.PARAM_SCOPE, AuthorizationRequest.SCOPE_EMAIL);
+        mRequestBuilder.setAdditionalParameters(additionalParams);
+    }
+
+    /* ******************************* toUri() ****************************************************/
 
     @Test
     public void testToUri() throws Exception {
-        Uri uri = mRequest.toUri();
-
-        Uri authEndpoint = mRequest.configuration.authorizationEndpoint;
-        assertThat(uri.getScheme()).isEqualTo(authEndpoint.getScheme());
-        assertThat(uri.getAuthority()).isEqualTo(authEndpoint.getAuthority());
-        assertThat(uri.getPath()).isEqualTo(authEndpoint.getPath());
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_REDIRECT_URI))
-                .isEqualTo(mRequest.redirectUri.toString());
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_CLIENT_ID))
-                .isEqualTo(mRequest.clientId);
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_RESPONSE_TYPE))
-                .isEqualTo(mRequest.responseType);
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_STATE))
-                .isEqualTo(mRequest.state);
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_SCOPE))
-                .isEqualTo(mRequest.scope);
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_RESPONSE_MODE))
-                .isEqualTo(mRequest.responseMode);
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_CODE_CHALLENGE))
-                .isEqualTo(mRequest.codeVerifierChallenge);
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_CODE_CHALLENGE_METHOD))
-                .isEqualTo(mRequest.codeVerifierChallengeMethod);
-    }
-
-    @Test
-    public void testToUri_withMinimalConfiguration() throws Exception {
-        AuthorizationRequest req = mMinimalRequestBuilder.build();
-
-        Uri uri = req.toUri();
+        AuthorizationRequest request = mRequestBuilder.build();
+        Uri uri = request.toUri();
         assertThat(uri.getQueryParameterNames())
                 .isEqualTo(new HashSet<>(Arrays.asList(
                         AuthorizationRequest.PARAM_CLIENT_ID,
@@ -362,29 +426,102 @@ public class AuthorizationRequestTest {
                         AuthorizationRequest.PARAM_STATE,
                         AuthorizationRequest.PARAM_CODE_CHALLENGE,
                         AuthorizationRequest.PARAM_CODE_CHALLENGE_METHOD)));
+
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_CLIENT_ID))
+                .isEqualTo(TEST_CLIENT_ID);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_RESPONSE_TYPE))
+                .isEqualTo(ResponseTypeValues.CODE);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_REDIRECT_URI))
+                .isEqualTo(TEST_APP_REDIRECT_URI.toString());
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_STATE))
+                .isEqualTo(request.state);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_CODE_CHALLENGE))
+                .isEqualTo(request.codeVerifierChallenge);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_CODE_CHALLENGE_METHOD))
+                .isEqualTo(request.codeVerifierChallengeMethod);
     }
 
     @Test
-    public void testToUri_withNoState() throws Exception {
-        AuthorizationRequest req = mMinimalRequestBuilder.setState(null).build();
-        assertThat(req.toUri().getQueryParameterNames())
-                .doesNotContain(AuthorizationRequest.PARAM_STATE);
-    }
-
-    @Test
-    public void testToUri_withNoVerifier() throws Exception {
-        AuthorizationRequest req = mMinimalRequestBuilder.setCodeVerifier(null).build();
+    public void testToUri_noCodeVerifier() throws Exception {
+        AuthorizationRequest req = mRequestBuilder.setCodeVerifier(null).build();
         assertThat(req.toUri().getQueryParameterNames())
                 .doesNotContain(AuthorizationRequest.PARAM_CODE_CHALLENGE)
                 .doesNotContain(AuthorizationRequest.PARAM_CODE_CHALLENGE_METHOD);
     }
 
     @Test
-    public void testToUri_withAdditionalParameters() throws Exception {
+    public void testToUri_displayParam() {
+        Uri uri = mRequestBuilder
+                .setDisplay(AuthorizationRequest.Display.PAGE)
+                .build()
+                .toUri();
+        assertThat(uri.getQueryParameterNames())
+                .contains(AuthorizationRequest.PARAM_DISPLAY);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_DISPLAY))
+                .isEqualTo(AuthorizationRequest.Display.PAGE);
+    }
+
+    @Test
+    public void testToUri_promptParam() {
+        Uri uri = mRequestBuilder
+                .setPrompt(AuthorizationRequest.Prompt.CONSENT)
+                .build()
+                .toUri();
+        assertThat(uri.getQueryParameterNames())
+                .contains(AuthorizationRequest.PARAM_PROMPT);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_PROMPT))
+                .isEqualTo(AuthorizationRequest.Prompt.CONSENT);
+    }
+
+    @Test
+    public void testToUri_responseModeParam() {
+        Uri uri = mRequestBuilder
+                .setResponseMode(AuthorizationRequest.RESPONSE_MODE_QUERY)
+                .build()
+                .toUri();
+        assertThat(uri.getQueryParameterNames())
+                .contains(AuthorizationRequest.PARAM_RESPONSE_MODE);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_RESPONSE_MODE))
+                .isEqualTo(AuthorizationRequest.RESPONSE_MODE_QUERY);
+    }
+
+    @Test
+    public void testToUri_scopeParam() {
+        Uri uri = mRequestBuilder
+                .setScope(AuthorizationRequest.SCOPE_EMAIL)
+                .build()
+                .toUri();
+        assertThat(uri.getQueryParameterNames())
+                .contains(AuthorizationRequest.PARAM_SCOPE);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_SCOPE))
+                .isEqualTo(AuthorizationRequest.SCOPE_EMAIL);
+    }
+
+    @Test
+    public void testToUri_stateParam() {
+        Uri uri = mRequestBuilder
+                .setState(TEST_STATE)
+                .build()
+                .toUri();
+        assertThat(uri.getQueryParameterNames())
+                .contains(AuthorizationRequest.PARAM_STATE);
+        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_STATE))
+                .isEqualTo(TEST_STATE);
+    }
+
+    @Test
+    public void testToUri_noStateParam() throws Exception {
+        AuthorizationRequest req = mRequestBuilder.setState(null).build();
+        assertThat(req.toUri().getQueryParameterNames())
+                .doesNotContain(AuthorizationRequest.PARAM_STATE);
+    }
+
+    @Test
+    public void testToUri_additionalParams() throws Exception {
         Map<String, String> additionalParams = new HashMap<>();
         additionalParams.put("my_param", "1234");
         additionalParams.put("another_param", "5678");
-        AuthorizationRequest req = mMinimalRequestBuilder
+        AuthorizationRequest req = mRequestBuilder
                 .setAdditionalParameters(additionalParams)
                 .build();
 
@@ -395,73 +532,98 @@ public class AuthorizationRequestTest {
                 .isEqualTo("5678");
     }
 
-    @Test
-    public void testToUri_withPrompt() throws Exception {
-        AuthorizationRequest req = mMinimalRequestBuilder
-                .setPrompt(AuthorizationRequest.Prompt.LOGIN)
-                .build();
+    /* ************************** jsonSerialize() / jsonDeserialize() *****************************/
 
-        Uri uri = req.toUri();
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_PROMPT))
-                .isEqualTo(AuthorizationRequest.Prompt.LOGIN);
+    @Test
+    public void testJsonSerialize_clientId() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setClientId(TEST_CLIENT_ID).build());
+        assertThat(copy.clientId).isEqualTo(TEST_CLIENT_ID);
     }
 
     @Test
-    public void testToUri_withDisplay() throws Exception {
-        AuthorizationRequest req = mMinimalRequestBuilder
-                .setDisplay(AuthorizationRequest.Display.TOUCH)
-                .build();
-
-        Uri uri = req.toUri();
-        assertThat(uri.getQueryParameter(AuthorizationRequest.PARAM_DISPLAY))
-                .isEqualTo(AuthorizationRequest.Display.TOUCH);
+    public void testJsonSerialize_display() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setDisplay(AuthorizationRequest.Display.POPUP).build());
+        assertThat(copy.display).isEqualTo(AuthorizationRequest.Display.POPUP);
     }
 
     @Test
-    public void testSerialization() throws Exception {
-        AuthorizationRequest request =
-                AuthorizationRequest.jsonDeserialize(mRequest.jsonSerialize());
-        assertValues(request);
+    public void testJsonSerialize_prompt() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setPrompt(AuthorizationRequest.Prompt.CONSENT).build());
+        assertThat(copy.prompt).isEqualTo(AuthorizationRequest.Prompt.CONSENT);
     }
 
     @Test
-    public void testSerialization_scopesNull() throws Exception {
-        AuthorizationRequest request = mRequestBuilder
-                .setScopes((Iterable<String>)null)
-                .build();
-        AuthorizationRequest newRequest =
-                AuthorizationRequest.jsonDeserialize(request.jsonSerialize());
-        assertNull(newRequest.scope);
+    public void testJsonSerialize_redirectUri() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setRedirectUri(TEST_APP_REDIRECT_URI).build());
+        assertThat(copy.redirectUri).isEqualTo(TEST_APP_REDIRECT_URI);
     }
 
     @Test
-    public void testSerialization_scopesEmpty() throws Exception {
-        AuthorizationRequest request = mRequestBuilder
-                .setScopes(Collections.<String>emptyList())
-                .build();
-        AuthorizationRequest newRequest =
-                AuthorizationRequest.jsonDeserialize(request.jsonSerialize());
-        assertNull(newRequest.scope);
+    public void testJsonSerialize_responseMode() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setResponseMode(AuthorizationRequest.RESPONSE_MODE_QUERY).build());
+        assertThat(copy.responseMode).isEqualTo(AuthorizationRequest.RESPONSE_MODE_QUERY);
     }
 
-    private void assertValues(AuthorizationRequest request) {
-        assertEquals("unexpected client ID", TEST_CLIENT_ID, request.clientId);
-        assertEquals("unexpected redirect URI", TEST_APP_REDIRECT_URI, request.redirectUri);
-        assertEquals("unexpected scope string", "openid email", request.scope);
-        assertEquals("unexpected state", TEST_STATE, request.state);
-        assertEquals("unexpected code verifier", TEST_CODE_VERIFIER, request.codeVerifier);
-        assertEquals("unexpected code verifier challenge",
-                TEST_CODE_VERIFIER, request.codeVerifierChallenge);
-        assertEquals("unexpected code verifier challenge method",
-                TEST_CODE_VERIFIER_CHALLENGE_METHOD, request.codeVerifierChallengeMethod);
-        assertEquals("unexpected response type",
-                ResponseTypeValues.CODE,
-                request.responseType);
-        assertEquals("unexpected response mode",
-                AuthorizationRequest.RESPONSE_MODE_QUERY,
-                request.responseMode);
-        assertEquals("unexpected additional params",
-                TEST_ADDITIONAL_PARAMS,
-                request.additionalParameters);
+    @Test
+    public void testJsonSerialize_responseType() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setResponseType(ResponseTypeValues.CODE).build());
+        assertThat(copy.responseType).isEqualTo(ResponseTypeValues.CODE);
+    }
+
+    @Test
+    public void testJsonSerialize_scope() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setScope(AuthorizationRequest.SCOPE_EMAIL).build());
+        assertThat(copy.scope).isEqualTo(AuthorizationRequest.SCOPE_EMAIL);
+    }
+
+    @Test
+    public void testSerialization_scopeNull() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setScopes((Iterable<String>)null).build());
+        assertThat(copy.scope).isNull();
+    }
+
+    @Test
+    public void testSerialization_scopeEmpty() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder
+                        .setScopes(Collections.<String>emptyList())
+                        .build());
+        assertThat(copy.scope).isNull();
+    }
+
+    @Test
+    public void testJsonSerialize_state() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setState(TEST_STATE).build());
+        assertThat(copy.state).isEqualTo(TEST_STATE);
+    }
+
+    @Test
+    public void testJsonSerialize_additionalParams() throws Exception {
+        AuthorizationRequest copy = serializeDeserialize(
+                mRequestBuilder.setAdditionalParameters(TEST_ADDITIONAL_PARAMS).build());
+        assertThat(copy.additionalParameters).isEqualTo(TEST_ADDITIONAL_PARAMS);
+    }
+
+    private AuthorizationRequest serializeDeserialize(AuthorizationRequest request)
+            throws JSONException {
+        return AuthorizationRequest.jsonDeserialize(request.jsonSerializeString());
+    }
+
+    private String generateString(int length) {
+        char[] chars = new char[length];
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = '0';
+        }
+
+        return new String(chars);
     }
 }

--- a/library/javatests/net/openid/appauth/PreconditionsTest.java
+++ b/library/javatests/net/openid/appauth/PreconditionsTest.java
@@ -95,7 +95,7 @@ public class PreconditionsTest {
         assertSame(testString, checkNotEmpty(testString, TEST_MSG));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testCheckNotEmpty_nullString() {
         checkNotEmpty(null, TEST_MSG);
     }

--- a/library/javatests/net/openid/appauth/TokenRequestTest.java
+++ b/library/javatests/net/openid/appauth/TokenRequestTest.java
@@ -60,7 +60,7 @@ public class TokenRequestTest {
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testBuild_nullClientId() {
         new TokenRequest.Builder(getTestServiceConfig(), null)
                 .build();


### PR DESCRIPTION
This also fixed the prompt serialization issue, by paying closer
attention to the builder, toUri and serialization behavior of
each parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/59)
<!-- Reviewable:end -->
