### PR TITLE
Store RegistrationResponse in AuthState.

### DIFF
--- a/app/src/net/openid/appauthdemo/IdentityProvider.java
+++ b/app/src/net/openid/appauthdemo/IdentityProvider.java
@@ -110,7 +110,6 @@ class IdentityProvider {
     private Uri mTokenEndpoint;
     private Uri mRegistrationEndpoint;
     private String mClientId;
-    private String mClientSecret;
     private Uri mRedirectUri;
     private String mScope;
 
@@ -215,17 +214,9 @@ class IdentityProvider {
         return mClientId;
     }
 
-    @Nullable
-    public String getClientSecret() {
-        return mClientSecret;
-    }
 
     public void setClientId(String clientId) {
         mClientId = clientId;
-    }
-
-    public void setClientSecret(String clientSecret) {
-        mClientSecret = clientSecret;
     }
 
     @NonNull

--- a/app/src/net/openid/appauthdemo/MainActivity.java
+++ b/app/src/net/openid/appauthdemo/MainActivity.java
@@ -29,6 +29,7 @@ import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import net.openid.appauth.AuthState;
 import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationRequest;
 import net.openid.appauth.AuthorizationService;
@@ -85,7 +86,7 @@ public class MainActivity extends AppCompatActivity {
                                     // Do dynamic client registration if no client_id
                                     makeRegistrationRequest(serviceConfiguration, idp);
                                 } else {
-                                    makeAuthRequest(serviceConfiguration, idp);
+                                    makeAuthRequest(serviceConfiguration, idp, new AuthState());
                                 }
                             }
                         }
@@ -127,7 +128,8 @@ public class MainActivity extends AppCompatActivity {
 
     private void makeAuthRequest(
             @NonNull AuthorizationServiceConfiguration serviceConfig,
-            @NonNull IdentityProvider idp) {
+            @NonNull IdentityProvider idp,
+            @NonNull AuthState authState) {
 
         AuthorizationRequest authRequest = new AuthorizationRequest.Builder(
                 serviceConfig,
@@ -144,7 +146,7 @@ public class MainActivity extends AppCompatActivity {
                         this,
                         authRequest,
                         serviceConfig.discoveryDoc,
-                        idp.getClientSecret()),
+                        authState),
                 mAuthService.createCustomTabsIntentBuilder()
                         .setToolbarColor(getColorCompat(R.color.colorAccent))
                         .build());
@@ -171,10 +173,10 @@ public class MainActivity extends AppCompatActivity {
                         Log.d(TAG, "Registration request complete");
                         if (registrationResponse != null) {
                             idp.setClientId(registrationResponse.clientId);
-                            idp.setClientSecret(registrationResponse.clientSecret);
                             Log.d(TAG, "Registration request complete successfully");
                             // Continue with the authentication
-                            makeAuthRequest(registrationResponse.request.configuration, idp);
+                            makeAuthRequest(registrationResponse.request.configuration, idp,
+                                    new AuthState((registrationResponse)));
                         }
                     }
                 });

--- a/library/java/net/openid/appauth/ClientAuthentication.java
+++ b/library/java/net/openid/appauth/ClientAuthentication.java
@@ -18,6 +18,25 @@ import java.util.Map;
 
 public interface ClientAuthentication {
     /**
+     * Thrown when a mandatory property is missing from the registration response.
+     */
+    class UnsupportedAuthenticationMethod extends Exception {
+        private String mAuthMethod;
+
+        /**
+         * Indicates that the specified client authentication method is unsupported.
+         */
+        public UnsupportedAuthenticationMethod(String field) {
+            super("Unsupported client authentication method: " + field);
+            mAuthMethod = field;
+        }
+
+        public String getUnsupportedAuthenticationMethod() {
+            return mAuthMethod;
+        }
+    }
+
+    /**
      * Constructs any extra parameters necessary to include in the request headers for the client
      * authentication.
      */

--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -41,6 +41,7 @@ public class RegistrationResponse {
     static final String PARAM_REGISTRATION_ACCESS_TOKEN = "registration_access_token";
     static final String PARAM_REGISTRATION_CLIENT_URI = "registration_client_uri";
     static final String PARAM_CLIENT_ID_ISSUED_AT = "client_id_issued_at";
+    static final String PARAM_TOKEN_ENDPOINT_AUTH_METHOD = "token_endpoint_auth_method";
 
     static final String KEY_REQUEST = "request";
     static final String KEY_ADDITIONAL_PARAMETERS = "additionalParameters";
@@ -51,7 +52,8 @@ public class RegistrationResponse {
             PARAM_CLIENT_SECRET_EXPIRES_AT,
             PARAM_REGISTRATION_ACCESS_TOKEN,
             PARAM_REGISTRATION_CLIENT_URI,
-            PARAM_CLIENT_ID_ISSUED_AT
+            PARAM_CLIENT_ID_ISSUED_AT,
+            PARAM_TOKEN_ENDPOINT_AUTH_METHOD
     ));
     /**
      * The registration request associated with this response.
@@ -118,11 +120,19 @@ public class RegistrationResponse {
     public final Uri registrationClientUri;
 
     /**
+     * Client authentication method to use at the token endpoint, if provided.
+     *
+     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">
+     * "OpenID Connect Core 1.0", Section 9</a>
+     */
+    @Nullable
+    public final String tokenEndpointAuthMethod;
+
+    /**
      * Additional, non-standard parameters in the response.
      */
     @NonNull
     public final Map<String, String> additionalParameters;
-
 
     /**
      * Thrown when a mandatory property is missing from the registration response.
@@ -159,6 +169,8 @@ public class RegistrationResponse {
         private String mRegistrationAccessToken;
         @Nullable
         private Uri mRegistrationClientUri;
+        @Nullable
+        private String mTokenEndpointAuthMethod;
 
         @NonNull
         private Map<String, String> mAdditionalParameters = Collections.emptyMap();
@@ -239,6 +251,14 @@ public class RegistrationResponse {
         }
 
         /**
+         * Specifies the client authentication method to use at the token endpoint.
+         */
+        public Builder setTokenEndpointAuthMethod(@Nullable String tokenEndpointAuthMethod) {
+            mTokenEndpointAuthMethod = tokenEndpointAuthMethod;
+            return this;
+        }
+
+        /**
          * Specifies the client configuration endpoint.
          *
          * @see <a href="https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse">
@@ -269,6 +289,7 @@ public class RegistrationResponse {
                     mClientSecretExpiresAt,
                     mRegistrationAccessToken,
                     mRegistrationClientUri,
+                    mTokenEndpointAuthMethod,
                     mAdditionalParameters);
         }
 
@@ -326,6 +347,8 @@ public class RegistrationResponse {
             setRegistrationAccessToken(JsonUtil.getStringIfDefined(json,
                     PARAM_REGISTRATION_ACCESS_TOKEN));
             setRegistrationClientUri(JsonUtil.getUriIfDefined(json, PARAM_REGISTRATION_CLIENT_URI));
+            setTokenEndpointAuthMethod(JsonUtil.getStringIfDefined(json,
+                    PARAM_TOKEN_ENDPOINT_AUTH_METHOD));
 
             setAdditionalParameters(extractAdditionalParams(json, BUILT_IN_PARAMS));
             return this;
@@ -340,6 +363,7 @@ public class RegistrationResponse {
             @Nullable Long clientSecretExpiresAt,
             @Nullable String registrationAccessToken,
             @Nullable Uri registrationClientUri,
+            @Nullable String tokenEndpointAuthMethod,
             @NonNull Map<String, String> additionalParameters) {
         this.request = request;
         this.clientId = clientId;
@@ -348,6 +372,7 @@ public class RegistrationResponse {
         this.clientSecretExpiresAt = clientSecretExpiresAt;
         this.registrationAccessToken = registrationAccessToken;
         this.registrationClientUri = registrationClientUri;
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
         this.additionalParameters = additionalParameters;
     }
 
@@ -355,7 +380,7 @@ public class RegistrationResponse {
      * Reads a registration response JSON string received from an authorization server,
      * and associates it with the provided request.
      *
-     * @throws JSONException if the JSON is malformed or missing required fields.
+     * @throws JSONException            if the JSON is malformed or missing required fields.
      * @throws MissingArgumentException if the JSON is missing fields required by the specification.
      */
     @NonNull
@@ -370,7 +395,7 @@ public class RegistrationResponse {
      * Reads a registration response JSON object received from an authorization server,
      * and associates it with the provided request.
      *
-     * @throws JSONException if the JSON is malformed or missing required fields.
+     * @throws JSONException            if the JSON is malformed or missing required fields.
      * @throws MissingArgumentException if the JSON is missing fields required by the specification.
      */
     @NonNull
@@ -398,6 +423,7 @@ public class RegistrationResponse {
         JsonUtil.putIfNotNull(json, PARAM_CLIENT_SECRET_EXPIRES_AT, clientSecretExpiresAt);
         JsonUtil.putIfNotNull(json, PARAM_REGISTRATION_ACCESS_TOKEN, registrationAccessToken);
         JsonUtil.putIfNotNull(json, PARAM_REGISTRATION_CLIENT_URI, registrationClientUri);
+        JsonUtil.putIfNotNull(json, PARAM_TOKEN_ENDPOINT_AUTH_METHOD, tokenEndpointAuthMethod);
         JsonUtil.put(json, KEY_ADDITIONAL_PARAMETERS,
                 JsonUtil.mapToJsonObject(additionalParameters));
         return json;
@@ -416,6 +442,7 @@ public class RegistrationResponse {
     /**
      * Reads a registration response from a JSON string representation produced by
      * {@link #jsonSerialize()}.
+     *
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
     public static RegistrationResponse jsonDeserialize(@NonNull JSONObject json)
@@ -441,6 +468,7 @@ public class RegistrationResponse {
      * Reads a registration response from a JSON string representation produced by
      * {@link #jsonSerializeString()}. This method is just a convenience wrapper for
      * {@link #jsonDeserialize(JSONObject)}, converting the JSON string to its JSON object form.
+     *
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
     @NonNull

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -47,7 +47,7 @@ public class RegistrationResponseTest {
     private static final String TEST_REGISTRATION_ACCESS_TOKEN = "test_access_token";
     private static final String TEST_REGISTRATION_CLIENT_URI =
             "https://test.openid.com/register?client_id=" + TEST_CLIENT_ID;
-
+    private static final String TEST_TOKEN_ENDPOINT_AUTH_METHOD = "client_secret_basic";
 
     private static final String TEST_JSON = "{\n"
             + " \"client_id\": \"" + TEST_CLIENT_ID + "\",\n"
@@ -56,7 +56,8 @@ public class RegistrationResponseTest {
             + " \"client_secret_expires_at\": \"" + TEST_CLIENT_SECRET_EXPIRES_AT + "\",\n"
             + " \"registration_access_token\": \"" + TEST_REGISTRATION_ACCESS_TOKEN + "\",\n"
             + " \"registration_client_uri\": \"" + TEST_REGISTRATION_CLIENT_URI + "\",\n"
-            + " \"application_type\": " + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\n"
+            + " \"application_type\": \"" + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\",\n"
+            + " \"token_endpoint_auth_method\": \"" + TEST_TOKEN_ENDPOINT_AUTH_METHOD + "\"\n"
             + "}";
 
     @RunWith(RobolectricTestRunner.class)
@@ -101,6 +102,8 @@ public class RegistrationResponseTest {
                     .isEqualTo(TEST_REGISTRATION_ACCESS_TOKEN);
             assertThat(JsonUtil.getUri(json, RegistrationResponse.PARAM_REGISTRATION_CLIENT_URI))
                     .isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
+            assertThat(json.getString(RegistrationResponse.PARAM_TOKEN_ENDPOINT_AUTH_METHOD))
+                    .isEqualTo(TEST_TOKEN_ENDPOINT_AUTH_METHOD);
         }
 
         @Test
@@ -151,6 +154,7 @@ public class RegistrationResponseTest {
             assertThat(response.registrationAccessToken).isEqualTo(TEST_REGISTRATION_ACCESS_TOKEN);
             assertThat(response.registrationClientUri)
                     .isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
+            assertThat(response.tokenEndpointAuthMethod).isEqualTo(TEST_TOKEN_ENDPOINT_AUTH_METHOD);
             assertThat(response.additionalParameters)
                     .containsEntry(RegistrationRequest.PARAM_APPLICATION_TYPE,
                             RegistrationRequest.APPLICATION_TYPE_NATIVE);

--- a/library/javatests/net/openid/appauth/TestValues.java
+++ b/library/javatests/net/openid/appauth/TestValues.java
@@ -115,4 +115,16 @@ class TestValues {
     public static RegistrationRequest getTestRegistrationRequest() {
         return getTestRegistrationRequestBuilder().build();
     }
+
+    public static RegistrationResponse.Builder getTestRegistrationResponseBuilder() {
+        return new RegistrationResponse.Builder(getTestRegistrationRequest())
+                .setClientId(TEST_CLIENT_ID);
+    }
+
+    public static RegistrationResponse getTestRegistrationResponse() {
+        return getTestRegistrationResponseBuilder()
+                .setClientSecret(TEST_CLIENT_SECRET)
+                .setClientSecretExpiresAt(TEST_CLIENT_SECRET_EXPIRES_AT)
+                .build();
+    }
 }


### PR DESCRIPTION
Make use of the stored RegistrationResponse when constructing token requests in the TokenActivity of the demo app.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/61)
<!-- Reviewable:end -->
