### PR TITLE
Pass PendingIntent to performAuthorizationRequest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ response is delivered via an intent to an activity of your choosing:
 
 ```java
 AuthorizationService service = new AuthorizationService(context);
+Intent postAuthIntent = new Intent(context, MyAuthResultHandlerActivity.class); 
 service.performAuthorizationRequest(
     req,
-    new Intent(context, MyAuthResultHandlerActivity.class));
+    PendingIntent.getActivity(context, req.hashCode(), postAuthIntent, 0));
 ```
 
 ### Handling the Redirect


### PR DESCRIPTION
`AuthorizationService.performAuthorizationRequest` expects a `PendingIntent` instead of a plain `Intent`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/69)
<!-- Reviewable:end -->
