### PR TITLE
Fix #72 - avoid path encoding in config URIs

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
@@ -39,13 +39,21 @@ import java.net.URL;
 public class AuthorizationServiceConfiguration {
 
     /**
-     * The standard path at which an OpenID Connect discovery document can be found under an
-     * issuer's base URI.
+     * The standard base path for well-known resources on domains.
+     * @see <a href="https://tools.ietf.org/html/rfc5785">RFC 5785: Defining Well-Known Uniform
+     * Resource Identifiers</a>
+     */
+    public static final String WELL_KNOWN_PATH =
+            ".well-known";
+
+    /**
+     * The standard resource under {@link #WELL_KNOWN_PATH .well-known} at which an OpenID Connect
+     * discovery document can be found under an issuer's base URI.
      * @see <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">"OpenID Connect
      * discovery"</a>
      */
-    public static final String OPENID_CONFIGURATION_WELL_KNOWN_PATH =
-            ".well-known/openid-configuration";
+    public static final String OPENID_CONFIGURATION_RESOURCE =
+            "openid-configuration";
 
     private static final String KEY_AUTHORIZATION_ENDPOINT = "authorizationEndpoint";
     private static final String KEY_TOKEN_ENDPOINT = "tokenEndpoint";
@@ -185,10 +193,14 @@ public class AuthorizationServiceConfiguration {
      */
     public static void fetchFromIssuer(@NonNull Uri openIdConnectIssuerUri,
             @NonNull RetrieveConfigurationCallback callback) {
-        Uri fullUri = openIdConnectIssuerUri.buildUpon()
-                .appendPath(OPENID_CONFIGURATION_WELL_KNOWN_PATH)
+        fetchFromUrl(buildConfigurationUriFromIssuer(openIdConnectIssuerUri), callback);
+    }
+
+    static Uri buildConfigurationUriFromIssuer(Uri openIdConnectIssuerUri) {
+        return openIdConnectIssuerUri.buildUpon()
+                .appendPath(WELL_KNOWN_PATH)
+                .appendPath(OPENID_CONFIGURATION_RESOURCE)
                 .build();
-        fetchFromUrl(fullUri, callback);
     }
 
     /**
@@ -200,12 +212,14 @@ public class AuthorizationServiceConfiguration {
      */
     public static void fetchFromUrl(@NonNull Uri openIdConnectDiscoveryUri,
             @NonNull RetrieveConfigurationCallback callback) {
-        fetchFromUrl(openIdConnectDiscoveryUri, callback,
+        fetchFromUrl(openIdConnectDiscoveryUri,
+                callback,
                 new AuthorizationService.DefaultUrlBuilder());
     }
 
     @VisibleForTesting
-    static void fetchFromUrl(@NonNull Uri openIdConnectDiscoveryUri,
+    static void fetchFromUrl(
+            @NonNull Uri openIdConnectDiscoveryUri,
             @NonNull RetrieveConfigurationCallback callback,
             @NonNull AuthorizationService.UrlBuilder urlBuilder) {
         checkNotNull(openIdConnectDiscoveryUri, "openIDConnectDiscoveryUri cannot be null");

--- a/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
@@ -14,6 +14,7 @@
 
 package net.openid.appauth;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -165,6 +166,28 @@ public class AuthorizationServiceConfigurationTest {
         assertEquals(TEST_AUTH_ENDPOINT, config.authorizationEndpoint.toString());
         assertEquals(TEST_TOKEN_ENDPOINT, config.tokenEndpoint.toString());
         assertEquals(TEST_REGISTRATION_ENDPOINT, config.registrationEndpoint.toString());
+    }
+
+    @Test
+    public void testBuildConfigurationUriFromIssuer() {
+        Uri issuerUri = Uri.parse("https://test.openid.com");
+        assertThat(AuthorizationServiceConfiguration.buildConfigurationUriFromIssuer(issuerUri))
+                .isEqualTo(TEST_DISCOVERY_URI);
+    }
+
+    @Test
+    public void testBuildConfigurationUriFromIssuer_withRootPath() {
+        Uri issuerUri = Uri.parse("https://test.openid.com/");
+        assertThat(AuthorizationServiceConfiguration.buildConfigurationUriFromIssuer(issuerUri))
+                .isEqualTo(TEST_DISCOVERY_URI);
+    }
+
+    @Test
+    public void testBuildConfigurationUriFromIssuer_withExtendedPath() {
+        Uri issuerUri = Uri.parse("https://test.openid.com/tenant1");
+        assertThat(AuthorizationServiceConfiguration.buildConfigurationUriFromIssuer(issuerUri))
+                .isEqualTo(Uri.parse(
+                        "https://test.openid.com/tenant1/.well-known/openid-configuration"));
     }
 
     @Test


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/73)
<!-- Reviewable:end -->
