### PR TITLE
Add note about gradle check target in contribution guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ discussing your proposal, or email the
 
 The AppAuth library follows the
 [Google Coding Style](https://google.github.io/styleguide/javaguide.html) for
-the Java language. Please review your own code for adherence to the standard.
+the Java language. Please review your own code for adherence to the standard
+and make sure to run the `check` gradle target.
 
 ## Pull Request Reviews
 


### PR DESCRIPTION
Just a text suggestion to clarify the existence of the gradle `check` target in the contribution guidelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/84)
<!-- Reviewable:end -->
