### PR TITLE
Fix for issue #88: handle missing registration endpoint

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
@@ -166,7 +166,7 @@ public class AuthorizationServiceConfiguration {
             return new AuthorizationServiceConfiguration(
                     JsonUtil.getUri(json, KEY_AUTHORIZATION_ENDPOINT),
                     JsonUtil.getUri(json, KEY_TOKEN_ENDPOINT),
-                    JsonUtil.getUri(json, KEY_REGISTRATION_ENDPOINT));
+                    JsonUtil.getUriIfDefined(json, KEY_REGISTRATION_ENDPOINT));
         }
     }
 

--- a/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
@@ -145,6 +145,19 @@ public class AuthorizationServiceConfigurationTest {
     }
 
     @Test
+    public void testSerializationWithoutRegistrationEndpoint() throws Exception {
+        AuthorizationServiceConfiguration config = new AuthorizationServiceConfiguration(
+                Uri.parse(TEST_AUTH_ENDPOINT),
+                Uri.parse(TEST_TOKEN_ENDPOINT),
+                null);
+        AuthorizationServiceConfiguration deserialized = AuthorizationServiceConfiguration
+                .fromJson(config.toJson());
+        assertThat(deserialized.authorizationEndpoint).isEqualTo(config.authorizationEndpoint);
+        assertThat(deserialized.tokenEndpoint).isEqualTo(config.tokenEndpoint);
+        assertThat(deserialized.registrationEndpoint).isNull();
+    }
+
+    @Test
     public void testDiscoveryConstructorWithName() throws Exception {
         JSONObject json = new JSONObject(TEST_JSON);
         AuthorizationServiceDiscovery discovery = new AuthorizationServiceDiscovery(json);


### PR DESCRIPTION
Fixes #88: since the registration endpoint is not required by the spec, it might not be set when trying to deserialize a serialized representation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/92)
<!-- Reviewable:end -->
