### PR TITLE
Disregard refresh token when deciding if access token is still fresh.

### DIFF
--- a/library/java/net/openid/appauth/AuthState.java
+++ b/library/java/net/openid/appauth/AuthState.java
@@ -306,10 +306,6 @@ public class AuthState {
 
     @VisibleForTesting
     boolean getNeedsTokenRefresh(Clock clock) {
-        if (getRefreshToken() == null) {
-            return false;
-        }
-
         if (mNeedsTokenRefreshOverride) {
             return true;
         }

--- a/library/javatests/net/openid/appauth/AuthStateTest.java
+++ b/library/javatests/net/openid/appauth/AuthStateTest.java
@@ -75,7 +75,7 @@ public class AuthStateTest {
         assertThat(state.getScope()).isNull();
         assertThat(state.getScopeSet()).isNull();
 
-        assertThat(state.getNeedsTokenRefresh(mClock)).isFalse();
+        assertThat(state.getNeedsTokenRefresh(mClock)).isTrue();
     }
 
     @Test
@@ -97,7 +97,7 @@ public class AuthStateTest {
         assertThat(state.getScope()).isEqualTo(authCodeRequest.scope);
         assertThat(state.getScopeSet()).isEqualTo(authCodeRequest.getScopeSet());
 
-        assertThat(state.getNeedsTokenRefresh(mClock)).isFalse();
+        assertThat(state.getNeedsTokenRefresh(mClock)).isTrue();
     }
 
     @Test
@@ -119,7 +119,7 @@ public class AuthStateTest {
 
         assertThat(state.getScope()).isNull();
         assertThat(state.getScopeSet()).isNull();
-        assertThat(state.getNeedsTokenRefresh(mClock)).isFalse();
+        assertThat(state.getNeedsTokenRefresh(mClock)).isTrue();
     }
 
     @Test
@@ -178,7 +178,7 @@ public class AuthStateTest {
 
         assertThat(state.getScope()).isNull();
         assertThat(state.getScopeSet()).isNull();
-        assertThat(state.getNeedsTokenRefresh(mClock)).isFalse();
+        assertThat(state.getNeedsTokenRefresh(mClock)).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -395,17 +395,6 @@ public class AuthStateTest {
         // ... force a refresh
         state.setNeedsTokenRefresh(true);
         assertThat(state.getNeedsTokenRefresh(mClock)).isTrue();
-    }
-
-    @Test
-    public void testSetNeedsTokenRefresh_hasNoEffectWithNoAccessToken() {
-        AuthState state = new AuthState(getTestAuthResponse(), null);
-
-        // in this scenario, we do not yet have a refresh or access token. Attempting to force
-        // a token refresh is meaningless.
-        assertThat(state.getNeedsTokenRefresh()).isFalse();
-        state.setNeedsTokenRefresh(true);
-        assertThat(state.getNeedsTokenRefresh()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Whether we have a refresh token or not is irrelevant for determining
if the access token is valid. The case where the access token has
expired and we have no refresh token is already signalled as an error
to the callback in performActionWithFreshTokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/93)
<!-- Reviewable:end -->
