### PR TITLE
Ensure state param in response matches request

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationException.java
+++ b/library/java/net/openid/appauth/AuthorizationException.java
@@ -269,6 +269,13 @@ public final class AuthorizationException extends Exception {
         public static final AuthorizationException OTHER =
                 authEx(1008, null);
 
+        /**
+         * Indicates that the response state param did not match the request state param,
+         * resulting in the response being discarded.
+         */
+        public static final AuthorizationException STATE_MISMATCH =
+                generalEx(9, "Response state param did not match request state");
+
         private static final Map<String, AuthorizationException> STRING_TO_EXCEPTION =
                 exceptionMapByString(
                         INVALID_REQUEST,

--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -23,6 +23,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.VisibleForTesting;
 
+import net.openid.appauth.AuthorizationException.AuthorizationRequestErrors;
 import org.json.JSONException;
 
 /**
@@ -289,6 +290,17 @@ public class AuthorizationManagementActivity extends Activity {
             AuthorizationResponse response = new AuthorizationResponse.Builder(mAuthRequest)
                     .fromUri(responseUri, mClock)
                     .build();
+
+            if (mAuthRequest.state == null && response.state != null
+                    || (mAuthRequest.state != null && !mAuthRequest.state.equals(response.state))) {
+                Logger.warn("State returned in authorization response (%s) does not match state "
+                        + "from request (%s) - discarding response",
+                        response.state,
+                        mAuthRequest.state);
+
+                return AuthorizationRequestErrors.STATE_MISMATCH.toIntent();
+            }
+
             return response.toIntent();
         }
     }


### PR DESCRIPTION
Failing to check the state was a regression introduced by the change from using a static store of requests to the AuthorizationManagementActivity - this is now corrected, with tests added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/111)
<!-- Reviewable:end -->
