### PR TITLE
Introduce ability to control creation of HttpUrlConnection instances

### DIFF
--- a/library/java/net/openid/appauth/AppAuthConfiguration.java
+++ b/library/java/net/openid/appauth/AppAuthConfiguration.java
@@ -18,6 +18,8 @@ import android.support.annotation.NonNull;
 
 import net.openid.appauth.browser.AnyBrowserMatcher;
 import net.openid.appauth.browser.BrowserMatcher;
+import net.openid.appauth.connectivity.ConnectionBuilder;
+import net.openid.appauth.connectivity.DefaultConnectionBuilder;
 
 /**
  * Defines configuration properties that control the behavior of the AppAuth library, independent
@@ -35,9 +37,14 @@ public class AppAuthConfiguration {
     @NonNull
     private final BrowserMatcher mBrowserMatcher;
 
+    @NonNull
+    private final ConnectionBuilder mConnectionBuilder;
+
     private AppAuthConfiguration(
-            @NonNull BrowserMatcher browserMatcher) {
+            @NonNull BrowserMatcher browserMatcher,
+            @NonNull ConnectionBuilder connectionBuilder) {
         mBrowserMatcher = browserMatcher;
+        mConnectionBuilder = connectionBuilder;
     }
 
     /**
@@ -49,16 +56,27 @@ public class AppAuthConfiguration {
     }
 
     /**
+     * Creates {@link java.net.HttpURLConnection} instances for use in token requests and related
+     * interactions with the authorization service.
+     */
+    @NonNull
+    public ConnectionBuilder getConnectionBuilder() {
+        return mConnectionBuilder;
+    }
+
+    /**
      * Creates {@link AppAuthConfiguration} instances.
      */
     public static class Builder {
 
         private BrowserMatcher mBrowserMatcher = AnyBrowserMatcher.INSTANCE;
+        private ConnectionBuilder mConnectionBuilder = DefaultConnectionBuilder.INSTANCE;
 
         /**
          * Specify the browser matcher to use, which controls the browsers that can be used
          * for authorization.
          */
+        @NonNull
         public Builder setBrowserMatcher(@NonNull BrowserMatcher browserMatcher) {
             Preconditions.checkNotNull(browserMatcher, "browserMatcher cannot be null");
             mBrowserMatcher = browserMatcher;
@@ -66,10 +84,24 @@ public class AppAuthConfiguration {
         }
 
         /**
+         * Specify the connection builder to use, which creates {@link java.net.HttpURLConnection}
+         * instances for use in direct communication with the authorization service.
+         */
+        @NonNull
+        public Builder setConnectionBuilder(@NonNull ConnectionBuilder connectionBuilder) {
+            Preconditions.checkNotNull(connectionBuilder, "connectionBuilder cannot be null");
+            mConnectionBuilder = connectionBuilder;
+            return this;
+        }
+
+        /**
          * Creates the instance from the configured properties.
          */
+        @NonNull
         public AppAuthConfiguration build() {
-            return new AppAuthConfiguration(mBrowserMatcher);
+            return new AppAuthConfiguration(mBrowserMatcher, mConnectionBuilder);
         }
+
+
     }
 }

--- a/library/java/net/openid/appauth/connectivity/ConnectionBuilder.java
+++ b/library/java/net/openid/appauth/connectivity/ConnectionBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth.connectivity;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * Creates {@link java.net.HttpURLConnection} instances for use in direct interactions
+ * with the authorization service, i.e. those not performed via a browser.
+ */
+public interface ConnectionBuilder {
+
+    /**
+     * Creates a connection to the specified URL.
+     * @throws IOException if an error occurs while attempting to establish the connection.
+     */
+    @NonNull
+    HttpURLConnection openConnection(@NonNull Uri uri) throws IOException;
+}

--- a/library/java/net/openid/appauth/connectivity/DefaultConnectionBuilder.java
+++ b/library/java/net/openid/appauth/connectivity/DefaultConnectionBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth.connectivity;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+
+import net.openid.appauth.Preconditions;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Creates {@link java.net.HttpURLConnection} instances using the default, platform-provided
+ * mechanism, with sensible production defaults.
+ */
+public final class DefaultConnectionBuilder implements ConnectionBuilder {
+
+    /**
+     * The singleton instance of the default connection builder.
+     */
+    public static final DefaultConnectionBuilder INSTANCE = new DefaultConnectionBuilder();
+
+    private static final int CONNECTION_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(15);
+    private static final int READ_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(10);
+
+    private static final String HTTPS_SCHEME = "https";
+
+    private DefaultConnectionBuilder() {
+        // no need to construct instances of this type
+    }
+
+    @NonNull
+    @Override
+    public HttpURLConnection openConnection(@NonNull Uri uri) throws IOException {
+        Preconditions.checkNotNull(uri, "url must not be null");
+        Preconditions.checkArgument(HTTPS_SCHEME.equals(uri.getScheme()),
+                "only https connections are permitted");
+        HttpURLConnection conn = (HttpURLConnection) new URL(uri.toString()).openConnection();
+        conn.setConnectTimeout(CONNECTION_TIMEOUT_MS);
+        conn.setReadTimeout(READ_TIMEOUT_MS);
+        conn.setInstanceFollowRedirects(false);
+        return conn;
+    }
+}

--- a/library/java/net/openid/appauth/connectivity/package-info.java
+++ b/library/java/net/openid/appauth/connectivity/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Types and utilities related to direct communication with servers.
+ */
+package net.openid.appauth.connectivity;


### PR DESCRIPTION
This allows a number of use cases:
- Disabling HTTPS checks for debug environments
- Configuring certificate pinning
- Using a different HTTP stack, such as okhttp or cronet

Fixes #115.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/120)
<!-- Reviewable:end -->
