### PR TITLE
Fixes and manual test capability for browser selection

### DIFF
--- a/app/java/net/openid/appauthdemo/BrowserSelectionAdapter.java
+++ b/app/java/net/openid/appauthdemo/BrowserSelectionAdapter.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauthdemo;
+
+import android.app.Activity;
+import android.app.LoaderManager.LoaderCallbacks;
+import android.content.AsyncTaskLoader;
+import android.content.Context;
+import android.content.Loader;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import net.openid.appauth.browser.BrowserDescriptor;
+import net.openid.appauth.browser.BrowserSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Loads the list of browsers on the device for selection in a list or spinner.
+ */
+public class BrowserSelectionAdapter extends BaseAdapter {
+
+    private static final int LOADER_ID = 101;
+
+    private Context mContext;
+    private ArrayList<BrowserInfo> mBrowsers;
+
+    /**
+     * Creates the adapter, using the loader manager from the specified activity.
+     */
+    public BrowserSelectionAdapter(@NonNull final Activity activity) {
+        mContext = activity;
+        initializeItemList();
+        activity.getLoaderManager().initLoader(
+                LOADER_ID,
+                null,
+                new BrowserLoaderCallbacks());
+    }
+
+    static final class BrowserInfo {
+        final BrowserDescriptor mDescriptor;
+        final CharSequence mLabel;
+        final Drawable mIcon;
+
+        BrowserInfo(BrowserDescriptor descriptor, CharSequence label, Drawable icon) {
+            mDescriptor = descriptor;
+            mLabel = label;
+            mIcon = icon;
+        }
+    }
+
+    @Override
+    public int getCount() {
+        return mBrowsers.size();
+    }
+
+    @Override
+    public BrowserInfo getItem(int position) {
+        return mBrowsers.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        if (convertView == null) {
+            convertView = LayoutInflater.from(mContext)
+                    .inflate(R.layout.browser_selector_layout, parent, false);
+        }
+
+        BrowserInfo info = mBrowsers.get(position);
+
+        TextView labelView = (TextView) convertView.findViewById(R.id.browser_label);
+        ImageView iconView = (ImageView) convertView.findViewById(R.id.browser_icon);
+        if (info == null) {
+            labelView.setText(R.string.browser_appauth_default_label);
+            iconView.setImageResource(R.drawable.openid_96dp);
+        } else {
+            CharSequence label = info.mLabel;
+            if (info.mDescriptor.useCustomTab) {
+                label = String.format(mContext.getString(R.string.custom_tab_label), label);
+            }
+            labelView.setText(label);
+            iconView.setImageDrawable(info.mIcon);
+        }
+
+        return convertView;
+    }
+
+    private void initializeItemList() {
+        mBrowsers = new ArrayList<>();
+        mBrowsers.add(null);
+    }
+
+    private final class BrowserLoaderCallbacks implements LoaderCallbacks<List<BrowserInfo>> {
+
+        @Override
+        public Loader<List<BrowserInfo>> onCreateLoader(int id, Bundle args) {
+            return new BrowserLoader(mContext);
+        }
+
+        @Override
+        public void onLoadFinished(Loader<List<BrowserInfo>> loader, List<BrowserInfo> data) {
+            initializeItemList();
+            mBrowsers.addAll(data);
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public void onLoaderReset(Loader<List<BrowserInfo>> loader) {
+            initializeItemList();
+            notifyDataSetChanged();
+        }
+    }
+
+    private static class BrowserLoader extends AsyncTaskLoader<List<BrowserInfo>> {
+
+        private List<BrowserInfo> mResult;
+
+        BrowserLoader(Context context) {
+            super(context);
+        }
+
+        @Override
+        public List<BrowserInfo> loadInBackground() {
+            List<BrowserDescriptor> descriptors = BrowserSelector.getAllBrowsers(getContext());
+            ArrayList<BrowserInfo> infos = new ArrayList<>(descriptors.size());
+
+            PackageManager pm = getContext().getPackageManager();
+            for (BrowserDescriptor descriptor : descriptors) {
+                try {
+                    ApplicationInfo info = pm.getApplicationInfo(descriptor.packageName, 0);
+                    CharSequence label = pm.getApplicationLabel(info);
+                    Drawable icon = pm.getApplicationIcon(descriptor.packageName);
+                    infos.add(new BrowserInfo(descriptor, label, icon));
+                } catch (NameNotFoundException e) {
+                    e.printStackTrace();
+                    infos.add(new BrowserInfo(descriptor, descriptor.packageName, null));
+                }
+            }
+
+            return infos;
+        }
+
+        @Override
+        public void deliverResult(List<BrowserInfo> data) {
+            if (isReset()) {
+                mResult = null;
+                return;
+            }
+
+            mResult = data;
+            super.deliverResult(mResult);
+        }
+
+        @Override
+        protected void onStartLoading() {
+            if (mResult != null) {
+                deliverResult(mResult);
+            }
+            forceLoad();
+        }
+
+        @Override
+        protected void onReset() {
+            mResult = null;
+        }
+
+        @Override
+        public void onCanceled(List<BrowserInfo> data) {
+            mResult = null;
+            super.onCanceled(data);
+        }
+    }
+}

--- a/app/res/layout/activity_main.xml
+++ b/app/res/layout/activity_main.xml
@@ -73,6 +73,18 @@
                   android:text="@string/account_id_description"/>
 
                 <TextView
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:layout_marginTop="8dp"
+                  android:text="@string/browser_selector_label"
+                  android:labelFor="@+id/browser_selector"/>
+
+                <Spinner
+                  android:id="@+id/browser_selector"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content" />
+
+                <TextView
                   android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:layout_gravity="center"

--- a/app/res/layout/browser_selector_layout.xml
+++ b/app/res/layout/browser_selector_layout.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation="horizontal"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:gravity="center_vertical"
+  android:padding="8dp">
+
+  <ImageView
+    android:id="@+id/browser_icon"
+    android:layout_width="32dp"
+    android:layout_height="32dp"
+    android:contentDescription="@string/browser_icon_contentDescription"/>
+
+  <TextView
+    android:id="@+id/browser_label"
+    android:layout_width="0dp"
+    android:layout_weight="1"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginLeft="8dp"/>
+
+</LinearLayout>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -22,4 +22,8 @@
     <string name="login_hint_value">Account ID (e.g. test@gmail.com)</string>
     <string name="account_id_description">The Account ID is optional. If specified, it is transmitted as a login_hint parameter in the authorization request.</string>
     <string name="auth_options">Authorization options:</string>
+    <string name="browser_selector_label">Use browser:</string>
+    <string name="browser_icon_contentDescription">Browser app icon</string>
+    <string name="browser_appauth_default_label">AppAuth heuristic selection</string>
+    <string name="custom_tab_label">"%1$s (custom tab)"</string>
 </resources>

--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -20,7 +20,8 @@
   <application>
     <activity android:name=".AuthorizationManagementActivity"
       android:exported="false"
-      android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+      android:theme="@android:style/Theme.Translucent.NoTitleBar"
+      android:launchMode="singleTask" />
 
     <activity android:name=".RedirectUriReceiverActivity" android:exported="true">
       <intent-filter>

--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -24,6 +24,7 @@ import android.os.Bundle;
 import android.support.annotation.VisibleForTesting;
 
 import net.openid.appauth.AuthorizationException.AuthorizationRequestErrors;
+
 import org.json.JSONException;
 
 /**
@@ -266,7 +267,9 @@ public class AuthorizationManagementActivity extends Activity {
 
     private void extractState(Bundle state) {
         if (state == null) {
-            throw new IllegalStateException("No state to extract");
+            Logger.warn("No stored state - unable to handle response");
+            finish();
+            return;
         }
 
         mAuthIntent = state.getParcelable(KEY_AUTH_INTENT);

--- a/library/java/net/openid/appauth/browser/BrowserDescriptor.java
+++ b/library/java/net/openid/appauth/browser/BrowserDescriptor.java
@@ -29,6 +29,9 @@ import java.util.Set;
  */
 public class BrowserDescriptor {
 
+    // See: http://stackoverflow.com/a/2816747
+    private static final int PRIME_HASH_FACTOR = 92821;
+
     private static final String DIGEST_SHA_512 = "SHA-512";
 
     /**
@@ -105,6 +108,37 @@ public class BrowserDescriptor {
                 signatureHashes,
                 version,
                 newUseCustomTabValue);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || !(obj instanceof BrowserDescriptor)) {
+            return false;
+        }
+
+        BrowserDescriptor other = (BrowserDescriptor) obj;
+        return this.packageName.equals(other.packageName)
+                && this.version.equals(other.version)
+                && this.useCustomTab == other.useCustomTab
+                && this.signatureHashes.equals(other.signatureHashes);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = packageName.hashCode();
+
+        hash = PRIME_HASH_FACTOR * hash + version.hashCode();
+        hash = PRIME_HASH_FACTOR * hash + (useCustomTab ? 1 : 0);
+
+        for (String signatureHash : signatureHashes) {
+            hash = PRIME_HASH_FACTOR * hash + signatureHash.hashCode();
+        }
+
+        return hash;
     }
 
     /**

--- a/library/java/net/openid/appauth/browser/ExactBrowserMatcher.java
+++ b/library/java/net/openid/appauth/browser/ExactBrowserMatcher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth.browser;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Matches only the specified browser.
+ */
+public class ExactBrowserMatcher implements BrowserMatcher {
+
+    private BrowserDescriptor mBrowser;
+
+    /**
+     * Creates a browser matcher that will only match the specified browser.
+     */
+    public ExactBrowserMatcher(BrowserDescriptor browser) {
+        mBrowser = browser;
+    }
+
+    @Override
+    public boolean matches(@NonNull BrowserDescriptor descriptor) {
+        return mBrowser.equals(descriptor);
+    }
+}

--- a/library/javatests/net/openid/appauth/browser/BrowserDescriptorTest.java
+++ b/library/javatests/net/openid/appauth/browser/BrowserDescriptorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth.browser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import net.openid.appauth.BuildConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk=16)
+public class BrowserDescriptorTest {
+
+    @Test
+    public void testEquals_toNull() {
+        assertThat(Browsers.Chrome.standaloneBrowser("45")).isNotEqualTo(null);
+    }
+
+    @Test
+    public void testEquals_toSelf() {
+        BrowserDescriptor browser = Browsers.Chrome.standaloneBrowser("45");
+        assertThat(browser).isEqualTo(browser);
+    }
+
+    @Test
+    public void testEquals_toEquivalent() {
+        BrowserDescriptor a = Browsers.Chrome.standaloneBrowser("45");
+        BrowserDescriptor b = Browsers.Chrome.standaloneBrowser("45");
+        assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    public void testEquals_differentVersion() {
+        BrowserDescriptor a = Browsers.Chrome.standaloneBrowser("45");
+        BrowserDescriptor b = Browsers.Chrome.standaloneBrowser("46");
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    public void testEquals_differentCustomTabSetting() {
+        BrowserDescriptor a = Browsers.Chrome.standaloneBrowser("45");
+        BrowserDescriptor b = Browsers.Chrome.customTab("45");
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    public void testEquals_differentSignatures() {
+        BrowserDescriptor a = Browsers.Chrome.standaloneBrowser("45");
+        BrowserDescriptor b = new BrowserDescriptor(
+                a.packageName,
+                Collections.<String>singleton("DIFFERENT_SIGNATURE"),
+                a.version,
+                a.useCustomTab);
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    public void testEquals_differentPackageNames() {
+        BrowserDescriptor a = Browsers.Chrome.standaloneBrowser("45");
+        BrowserDescriptor b = new BrowserDescriptor(
+                Browsers.Firefox.PACKAGE_NAME,
+                a.signatureHashes,
+                a.version,
+                a.useCustomTab);
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    public void testHashCode_equivalent() {
+        BrowserDescriptor a = Browsers.Chrome.standaloneBrowser("45");
+        BrowserDescriptor b = Browsers.Chrome.standaloneBrowser("45");
+
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    public void testHashCode_notEquivalent() {
+        BrowserDescriptor a = Browsers.Chrome.standaloneBrowser("45");
+        BrowserDescriptor b = Browsers.Chrome.standaloneBrowser("46");
+
+        assertThat(a.hashCode()).isNotEqualTo(b.hashCode());
+    }
+}


### PR DESCRIPTION
This change adds the ability to explicitly choose the browser to use in the demo app, making it easier to test the authorization flow against specific browsers. This uncovered an issue in AuthorizationManagementActivity when using a standalone browser:

- `launchMode=singleTask` is required to ensure that the correct activity instance is reached. This also has the side effect that only one browser-based interaction can happen at a time, but this is a reasonable assumption for the library to make.

- Failing to find stored state for handling a redirect no longer causes an IllegalStateException, and instead simply finishes the management activity. This can happen where the user switches back and forth between the app and browser, resulting in the flow being cancelled and then resumed after the state is lost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/121)
<!-- Reviewable:end -->
