### PR TITLE
Check Response Code before using conn.getInputStream

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -345,7 +345,12 @@ public class AuthorizationService {
                 wr.write(queryData);
                 wr.flush();
 
-                is = conn.getInputStream();
+                if (conn.getResponseCode() >= HttpURLConnection.HTTP_OK
+                        && conn.getResponseCode() < HttpURLConnection.HTTP_MULT_CHOICE) {
+                    is = conn.getInputStream();
+                } else {
+                    is = conn.getErrorStream();
+                }
                 String response = Utils.readInputStream(is);
                 return new JSONObject(response);
             } catch (IOException ex) {
@@ -378,7 +383,7 @@ public class AuthorizationService {
                             error,
                             json.getString(AuthorizationException.PARAM_ERROR_DESCRIPTION),
                             UriUtil.parseUriIfAvailable(
-                                    json.getString(AuthorizationException.PARAM_ERROR_URI)));
+                                    json.optString(AuthorizationException.PARAM_ERROR_URI)));
                 } catch (JSONException jsonEx) {
                     ex = AuthorizationException.fromTemplate(
                             GeneralErrors.JSON_DESERIALIZATION_ERROR,


### PR DESCRIPTION
If the response code is a non 200, use conn.getErrorStream instead.
This will allow things like token refresh errors to be handled correctly.
Currently, you get an AuthorizationException with a FileNotFoundException
as it's cause due to the call to conn.getInputStream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/144)
<!-- Reviewable:end -->
