### PR TITLE
Added ability to pass CustomTabsCallback when building CustomTabsIntent.

### DIFF
--- a/app/java/net/openid/appauthdemo/MainActivity.java
+++ b/app/java/net/openid/appauthdemo/MainActivity.java
@@ -202,7 +202,7 @@ public class MainActivity extends AppCompatActivity {
                         authRequest,
                         serviceConfig.discoveryDoc,
                         authState),
-                mAuthService.createCustomTabsIntentBuilder()
+                mAuthService.createCustomTabsIntentBuilder(null)
                         .setToolbarColor(getColorCompat(R.color.colorAccent))
                         .build());
     }

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -25,6 +25,7 @@ import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.support.customtabs.CustomTabsCallback;
 import android.support.customtabs.CustomTabsIntent;
 
 import net.openid.appauth.AuthorizationException.GeneralErrors;
@@ -112,9 +113,9 @@ public class AuthorizationService {
      * Creates a custom tab builder, that will use a tab session from an existing connection to
      * a web browser, if available.
      */
-    public CustomTabsIntent.Builder createCustomTabsIntentBuilder() {
+    public CustomTabsIntent.Builder createCustomTabsIntentBuilder(@Nullable CustomTabsCallback callback) {
         checkNotDisposed();
-        return mCustomTabManager.createCustomTabsIntentBuilder();
+        return mCustomTabManager.createCustomTabsIntentBuilder(callback);
     }
 
     /**
@@ -133,7 +134,7 @@ public class AuthorizationService {
                 request,
                 completedIntent,
                 null,
-                createCustomTabsIntentBuilder().build());
+                createCustomTabsIntentBuilder(null).build());
     }
 
     /**
@@ -154,7 +155,7 @@ public class AuthorizationService {
                 request,
                 completedIntent,
                 canceledIntent,
-                createCustomTabsIntentBuilder().build());
+                createCustomTabsIntentBuilder(null).build());
     }
 
     /**
@@ -167,7 +168,7 @@ public class AuthorizationService {
      *
      * @param customTabsIntent
      *     The intent that will be used to start the custom tab. It is recommended that this intent
-     *     be created with the help of {@link #createCustomTabsIntentBuilder()}, which will ensure
+     *     be created with the help of {@link #createCustomTabsIntentBuilder(CustomTabsCallback)} ()}, which will ensure
      *     that a warmed-up version of the browser will be used, minimizing latency.
      */
     public void performAuthorizationRequest(
@@ -192,7 +193,7 @@ public class AuthorizationService {
      *
      * @param customTabsIntent
      *     The intent that will be used to start the custom tab. It is recommended that this intent
-     *     be created with the help of {@link #createCustomTabsIntentBuilder()}, which will ensure
+     *     be created with the help of {@link #createCustomTabsIntentBuilder(CustomTabsCallback)} ()}, which will ensure
      *     that a warmed-up version of the browser will be used, minimizing latency.
      *
      * @throws android.content.ActivityNotFoundException if no suitable browser is available to

--- a/library/java/net/openid/appauth/CustomTabManager.java
+++ b/library/java/net/openid/appauth/CustomTabManager.java
@@ -18,6 +18,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.customtabs.CustomTabsCallback;
 import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.customtabs.CustomTabsServiceConnection;
@@ -92,8 +93,8 @@ class CustomTabManager {
         }
     }
 
-    public CustomTabsIntent.Builder createCustomTabsIntentBuilder() {
-        return new CustomTabsIntent.Builder(createSession());
+    public CustomTabsIntent.Builder createCustomTabsIntentBuilder(@Nullable CustomTabsCallback tabsCallback) {
+        return new CustomTabsIntent.Builder(createSession(tabsCallback));
     }
 
     public synchronized void unbind() {
@@ -106,7 +107,7 @@ class CustomTabManager {
         Logger.debug("CustomTabsService is disconnected");
     }
 
-    private CustomTabsSession createSession() {
+    private CustomTabsSession createSession(@Nullable CustomTabsCallback tabsCallback) {
         try {
             mClientLatch.await(CLIENT_WAIT_TIME, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
@@ -116,7 +117,7 @@ class CustomTabManager {
 
         CustomTabsClient client = mClient.get();
         if (client != null) {
-            return client.newSession(null);
+            return client.newSession(tabsCallback);
         }
 
         return null;

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -124,7 +124,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getOutputStream()).thenReturn(mOutputStream);
         when(mContext.bindService(serviceIntentEq(), any(CustomTabsServiceConnection.class),
                 anyInt())).thenReturn(true);
-        when(mCustomTabManager.createCustomTabsIntentBuilder())
+        when(mCustomTabManager.createCustomTabsIntentBuilder(null))
                 .thenReturn(new CustomTabsIntent.Builder());
     }
 


### PR DESCRIPTION
A little PR, a kind of feature request. This thing is really missing. I prefer to have my own callback and manage different states of the tab. In example when users goes to recents - CustomTabActivity is removed  as we get back to our app, because we have the flag intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY). It will be nice to have such callback as we will also have a chance to make an assumption when user had closed the tab by clicking the close button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/146)
<!-- Reviewable:end -->
