### PR TITLE
Allow custom tab to remain in back stack

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -223,7 +223,6 @@ public class AuthorizationService {
                 intent.getPackage(),
                 mBrowser.useCustomTab.toString());
         intent.putExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
 
         Logger.debug("Initiating authorization request to %s",
                 request.configuration.authorizationEndpoint);

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -377,7 +377,6 @@ public class AuthorizationServiceTest {
 
     private void assertRequestIntent(Intent intent, Integer color) {
         assertEquals(Intent.ACTION_VIEW, intent.getAction());
-        assertTrue((intent.getFlags() & Intent.FLAG_ACTIVITY_NO_HISTORY) > 0);
         assertColorMatch(intent, color);
     }
 


### PR DESCRIPTION
With the changes to retain way the browser intent is launched
in recent versions (AuthorizationManagementActivity etc.) it
is now possible to retain custom tabs on the back stack, which
provides a better experience when switching apps in the middle
of an authorization flow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/150)
<!-- Reviewable:end -->
