### PR TITLE
Allow proper error parsing with no error_description is given.

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -380,7 +380,7 @@ public class AuthorizationService {
                     ex = AuthorizationException.fromOAuthTemplate(
                             TokenRequestErrors.byString(error),
                             error,
-                            json.getString(AuthorizationException.PARAM_ERROR_DESCRIPTION),
+                            json.optString(AuthorizationException.PARAM_ERROR_DESCRIPTION, null),
                             UriUtil.parseUriIfAvailable(
                                     json.optString(AuthorizationException.PARAM_ERROR_URI)));
                 } catch (JSONException jsonEx) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/156)
<!-- Reviewable:end -->
