### PR TITLE
set content-type for dynamic registration request

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -453,6 +453,7 @@ public class AuthorizationService {
                         mClientConfiguration.getConnectionBuilder()
                                 .openConnection(mRequest.configuration.registrationEndpoint);
                 conn.setRequestMethod("POST");
+                conn.setRequestProperty("Content-Type", "application/json");
                 conn.setDoOutput(true);
                 conn.setRequestProperty("Content-Length", String.valueOf(postData.length()));
                 OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());


### PR DESCRIPTION
while servers should expect and only accept json bodies some parsers out there would not parse the body without an appropriate content-type being set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-android/180)
<!-- Reviewable:end -->
