### PR TITLE
Disable Jack compiler

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -30,7 +30,7 @@
         <!-- Main activity -->
         <activity
                 android:name=".LoginActivity"
-                android:label="@string/login_header"
+                android:label="@string/app_name_short"
                 android:theme="@style/AppTheme"
                 android:windowSoftInputMode="stateHidden" >
             <intent-filter>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.tatarka.retrolambda" version "3.6.0"
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 apply from: '../config/android-common.gradle'
@@ -14,15 +18,6 @@ android {
         manifestPlaceholders = [
                 'appAuthRedirectScheme': 'net.openid.appauthdemo'
         ]
-
-        jackOptions {
-            enabled true
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     signingConfigs {
@@ -32,6 +27,11 @@ android {
             keyAlias "appauth"
             keyPassword "appauth"
         }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -27,5 +27,4 @@
     <string name="no_access_token_expiry">Access time has no defined expiry</string>
     <string name="access_token_expired">Access token has expired</string>
     <string name="auth_settings">Authorization settings in use:</string>
-    <string name="login_header">Authorization</string>
 </resources>


### PR DESCRIPTION
Jack is now deprecated:

https://android-developers.googleblog.com/2017/03/future-of-java-8-language-feature.html

In order to continue to support Java 8 features in the demo app,
retrolambda is temporarily introduced until official Java 8 support
is provided in the Android SDK.

Fixes #190.