### PR TITLE
Do not add client_id by default on all token requests

### DIFF
--- a/library/java/net/openid/appauth/ClientAuthentication.java
+++ b/library/java/net/openid/appauth/ClientAuthentication.java
@@ -14,6 +14,8 @@
 
 package net.openid.appauth;
 
+import android.support.annotation.NonNull;
+
 import java.util.Map;
 
 public interface ClientAuthentication {
@@ -40,11 +42,11 @@ public interface ClientAuthentication {
      * Constructs any extra parameters necessary to include in the request headers for the client
      * authentication.
      */
-    Map<String, String> getRequestHeaders(String clientId);
+    Map<String, String> getRequestHeaders(@NonNull String clientId);
 
     /**
      * Constructs any extra parameters necessary to include in the request body for the client
      * authentication.
      */
-    Map<String, String> getRequestParameters(String clientId);
+    Map<String, String> getRequestParameters(@NonNull String clientId);
 }

--- a/library/java/net/openid/appauth/ClientSecretBasic.java
+++ b/library/java/net/openid/appauth/ClientSecretBasic.java
@@ -49,14 +49,14 @@ public class ClientSecretBasic implements ClientAuthentication {
     }
 
     @Override
-    public final Map<String, String> getRequestHeaders(String clientId) {
+    public final Map<String, String> getRequestHeaders(@NonNull String clientId) {
         String credentials = clientId + ":" + mClientSecret;
         String basicAuth = Base64.encodeToString(credentials.getBytes(), Base64.NO_WRAP);
         return Collections.singletonMap("Authorization", "Basic " + basicAuth);
     }
 
     @Override
-    public final Map<String, String> getRequestParameters(String clientId) {
+    public final Map<String, String> getRequestParameters(@NonNull String clientId) {
         return null;
     }
 }

--- a/library/java/net/openid/appauth/ClientSecretPost.java
+++ b/library/java/net/openid/appauth/ClientSecretPost.java
@@ -51,7 +51,7 @@ public class ClientSecretPost implements ClientAuthentication {
     }
 
     @Override
-    public final Map<String, String> getRequestParameters(String clientId) {
+    public final Map<String, String> getRequestParameters(@NonNull String clientId) {
         Map<String, String> additionalParameters = new HashMap<>();
         additionalParameters.put(PARAM_CLIENT_ID, clientId);
         additionalParameters.put(PARAM_CLIENT_SECRET, mClientSecret);
@@ -59,7 +59,7 @@ public class ClientSecretPost implements ClientAuthentication {
     }
 
     @Override
-    public final Map<String, String> getRequestHeaders(String clientId) {
+    public final Map<String, String> getRequestHeaders(@NonNull String clientId) {
         return null;
     }
 }

--- a/library/java/net/openid/appauth/NoClientAuthentication.java
+++ b/library/java/net/openid/appauth/NoClientAuthentication.java
@@ -14,6 +14,9 @@
 
 package net.openid.appauth;
 
+import android.support.annotation.NonNull;
+
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -46,17 +49,18 @@ public class NoClientAuthentication implements ClientAuthentication {
      * @return always `null`.
      */
     @Override
-    public Map<String, String> getRequestHeaders(String clientId) {
+    public Map<String, String> getRequestHeaders(@NonNull String clientId) {
         return null;
     }
 
     /**
      * {@inheritDoc}
      *
-     * @return always `null`.
+     * Where no alternative form of client authentication is used, the client_id is simply
+     * sent as a client identity assertion.
      */
     @Override
-    public Map<String, String> getRequestParameters(String clientId) {
-        return null;
+    public Map<String, String> getRequestParameters(@NonNull String clientId) {
+        return Collections.singletonMap(TokenRequest.PARAM_CLIENT_ID, clientId);
     }
 }

--- a/library/java/net/openid/appauth/TokenRequest.java
+++ b/library/java/net/openid/appauth/TokenRequest.java
@@ -63,8 +63,7 @@ public class TokenRequest {
     @VisibleForTesting
     static final String KEY_ADDITIONAL_PARAMETERS = "additionalParameters";
 
-    @VisibleForTesting
-    static final String PARAM_CLIENT_ID = "client_id";
+    public static final String PARAM_CLIENT_ID = "client_id";
 
     @VisibleForTesting
     static final String PARAM_CODE = "code";
@@ -490,7 +489,6 @@ public class TokenRequest {
     public Map<String, String> getRequestParameters() {
         Map<String, String> params = new HashMap<>();
         params.put(PARAM_GRANT_TYPE, grantType);
-        params.put(PARAM_CLIENT_ID, clientId);
         putIfNotNull(params, PARAM_REDIRECT_URI, redirectUri);
         putIfNotNull(params, PARAM_CODE, authorizationCode);
         putIfNotNull(params, PARAM_REFRESH_TOKEN, refreshToken);

--- a/library/java/net/openid/appauth/UriUtil.java
+++ b/library/java/net/openid/appauth/UriUtil.java
@@ -17,11 +17,15 @@ package net.openid.appauth;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.util.Pair;
 import android.text.TextUtils;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,5 +85,39 @@ class UriUtil {
             }
         }
         return TextUtils.join("&", queryParts);
+    }
+
+    public static List<Pair<String, String>> formUrlDecode(String encoded) {
+        if (TextUtils.isEmpty(encoded)) {
+            return Collections.emptyList();
+        }
+
+        String[] parts = encoded.split("&");
+        List<Pair<String, String>> params = new ArrayList<>();
+
+        for (String part : parts) {
+            String[] paramAndValue = part.split("=");
+            String param = paramAndValue[0];
+            String encodedValue = paramAndValue[1];
+
+            try {
+                params.add(Pair.create(param, URLDecoder.decode(encodedValue, "utf-8")));
+            } catch (UnsupportedEncodingException ex) {
+                Logger.error("Unable to decode parameter, ignoring", ex);
+            }
+        }
+
+        return params;
+    }
+
+    public static Map<String, String> formUrlDecodeUnique(String encoded) {
+        List<Pair<String, String>> params = UriUtil.formUrlDecode(encoded);
+        Map<String, String> uniqueParams = new HashMap<>();
+
+        for (Pair<String, String> param : params) {
+            uniqueParams.put(param.first, param.second);
+        }
+
+        return uniqueParams;
     }
 }

--- a/library/javatests/net/openid/appauth/NoClientAuthenticationTest.java
+++ b/library/javatests/net/openid/appauth/NoClientAuthenticationTest.java
@@ -15,6 +15,7 @@
 package net.openid.appauth;
 
 
+import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -26,11 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk=16)
 public class NoClientAuthenticationTest {
-    @Test
-    public void testGetInstance() {
-        assertThat(NoClientAuthentication.INSTANCE)
-                .isSameAs(NoClientAuthentication.INSTANCE);
-    }
 
     @Test
     public void testGetRequestHeaders() {
@@ -40,6 +36,6 @@ public class NoClientAuthenticationTest {
     @Test
     public void testGetRequestParameters() {
         assertThat(NoClientAuthentication.INSTANCE.getRequestParameters(TEST_CLIENT_ID))
-                .isNull();
+                .containsExactly(MapEntry.entry(TokenRequest.PARAM_CLIENT_ID, TEST_CLIENT_ID));
     }
 }

--- a/library/javatests/net/openid/appauth/TokenRequestTest.java
+++ b/library/javatests/net/openid/appauth/TokenRequestTest.java
@@ -124,9 +124,6 @@ public class TokenRequestTest {
                 TokenRequest.PARAM_GRANT_TYPE,
                 GrantTypeValues.AUTHORIZATION_CODE);
         assertThat(params).containsEntry(
-                TokenRequest.PARAM_CLIENT_ID,
-                TEST_CLIENT_ID);
-        assertThat(params).containsEntry(
                 TokenRequest.PARAM_CODE,
                 TEST_AUTHORIZATION_CODE);
         assertThat(params).containsEntry(
@@ -144,9 +141,6 @@ public class TokenRequestTest {
         assertThat(params).containsEntry(
                 TokenRequest.PARAM_GRANT_TYPE,
                 GrantTypeValues.REFRESH_TOKEN);
-        assertThat(params).containsEntry(
-                TokenRequest.PARAM_CLIENT_ID,
-                TEST_CLIENT_ID);
         assertThat(params).containsEntry(
                 TokenRequest.PARAM_REFRESH_TOKEN,
                 TEST_REFRESH_TOKEN);


### PR DESCRIPTION
Fixes #181 - NoClientAuthentication now adds the client ID explicitly,
rather than adding it to every token request, which fixes the issue
with ClientSecretBasic. ClientSecretPost was explicitly adding
client_id anyway, so no new issues introduced there.