### PR TITLE
Allow explicit client authentication for fresh tokens

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -244,10 +244,7 @@ public class AuthorizationService {
     public void performTokenRequest(
             @NonNull TokenRequest request,
             @NonNull TokenResponseCallback callback) {
-        checkNotDisposed();
-        Logger.debug("Initiating code exchange request to %s",
-                request.configuration.tokenEndpoint);
-        new TokenRequestTask(request, NoClientAuthentication.INSTANCE, callback).execute();
+        performTokenRequest(request, NoClientAuthentication.INSTANCE, callback);
     }
 
     /**

--- a/library/javatests/net/openid/appauth/AuthStateTest.java
+++ b/library/javatests/net/openid/appauth/AuthStateTest.java
@@ -28,6 +28,7 @@ import static net.openid.appauth.TestValues.getTestAuthResponseBuilder;
 import static net.openid.appauth.TestValues.getTestRegistrationResponse;
 import static net.openid.appauth.TestValues.getTestRegistrationResponseBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -419,6 +420,7 @@ public class AuthStateTest {
         mClock.currentTime.set(ONE_SECOND);
         state.performActionWithFreshTokens(
                 service,
+                NoClientAuthentication.INSTANCE,
                 Collections.<String, String>emptyMap(),
                 mClock,
                 action);
@@ -456,6 +458,7 @@ public class AuthStateTest {
         mClock.currentTime.set(TWO_MINUTES - AuthState.EXPIRY_TIME_TOLERANCE_MS + ONE_SECOND);
         state.performActionWithFreshTokens(
                 service,
+                NoClientAuthentication.INSTANCE,
                 Collections.<String, String>emptyMap(),
                 mClock,
                 action);
@@ -466,6 +469,7 @@ public class AuthStateTest {
                 ArgumentCaptor.forClass(AuthorizationService.TokenResponseCallback.class);
         verify(service, times(1)).performTokenRequest(
                 requestCaptor.capture(),
+                any(ClientAuthentication.class),
                 callbackCaptor.capture());
 
         assertThat(requestCaptor.getValue().refreshToken).isEqualTo(tokenResp.refreshToken);


### PR DESCRIPTION
Based on the discussion in #178, allow client authentication method override
for calls to `performActionWithFreshTokens`. Fixes #179.