### PR TITLE
Maven central sync settings

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -52,3 +52,36 @@ bintray {
     }
     configurations = ["archives"]
 }
+
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                packaging 'aar'
+                name 'AppAuth for Android'
+                url 'https://github.com/openid/AppAuth-Android'
+                licenses {
+                    license {
+                        name "The Apache Software License, Version 2.0"
+                        url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution "repo"
+                    }
+                }
+
+                developers {
+                    developer {
+                        id "iainmcgin"
+                        name "Iain McGinniss"
+                        email "iainmcgin@google.com"
+                    }
+                }
+
+                scm {
+                    connection "https://github.com/openid/AppAuth-Android.git"
+                    developerConnection "https://github.com/openid/AppAuth-Android.git"
+                    url 'https://github.com/openid/AppAuth-Android'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have the permissions required to start syncing our library to Maven Central. In order for this to work, we need extra information injected into our POM file.