### PR TITLE
Fix JSON deserialization

### DIFF
--- a/library/java/net/openid/appauth/RegistrationResponse.java
+++ b/library/java/net/openid/appauth/RegistrationResponse.java
@@ -55,6 +55,7 @@ public class RegistrationResponse {
             PARAM_CLIENT_ID_ISSUED_AT,
             PARAM_TOKEN_ENDPOINT_AUTH_METHOD
     ));
+
     /**
      * The registration request associated with this response.
      */
@@ -449,16 +450,22 @@ public class RegistrationResponse {
             throw new IllegalArgumentException("registration request not found in JSON");
         }
 
-        try {
-            return new Builder(
-                    RegistrationRequest.jsonDeserialize(json.getJSONObject(KEY_REQUEST)))
-                    .fromResponseJson(json)
-                    .build();
-        } catch (MissingArgumentException e) {
-            // as the missing argument should have been present in the original JSON during
-            // serialization, we can treat missing arguments as malformed JSON in this case.
-            throw new JSONException("missing required field: " + e.getMissingField());
-        }
+        return new Builder(
+                RegistrationRequest.jsonDeserialize(json.getJSONObject(KEY_REQUEST)))
+                .setClientId(JsonUtil.getString(json, PARAM_CLIENT_ID))
+                .setClientIdIssuedAt(JsonUtil.getLongIfDefined(json, PARAM_CLIENT_ID_ISSUED_AT))
+                .setClientSecret(JsonUtil.getStringIfDefined(json, PARAM_CLIENT_SECRET))
+                .setClientSecretExpiresAt(
+                        JsonUtil.getLongIfDefined(json, PARAM_CLIENT_SECRET_EXPIRES_AT))
+                .setRegistrationAccessToken(
+                        JsonUtil.getStringIfDefined(json, PARAM_REGISTRATION_ACCESS_TOKEN))
+                .setRegistrationClientUri(
+                        JsonUtil.getUriIfDefined(json, PARAM_REGISTRATION_CLIENT_URI))
+                .setTokenEndpointAuthMethod(
+                        JsonUtil.getStringIfDefined(json, PARAM_TOKEN_ENDPOINT_AUTH_METHOD))
+                .setAdditionalParameters(
+                        JsonUtil.getStringMap(json, KEY_ADDITIONAL_PARAMETERS))
+                .build();
     }
 
     /**

--- a/library/java/net/openid/appauth/TokenResponse.java
+++ b/library/java/net/openid/appauth/TokenResponse.java
@@ -471,7 +471,13 @@ public class TokenResponse {
         }
         return new TokenResponse.Builder(
                 TokenRequest.jsonDeserialize(json.getJSONObject(KEY_REQUEST)))
-                .fromResponseJson(json)
+                .setTokenType(JsonUtil.getStringIfDefined(json, KEY_TOKEN_TYPE))
+                .setAccessToken(JsonUtil.getStringIfDefined(json, KEY_ACCESS_TOKEN))
+                .setAccessTokenExpirationTime(JsonUtil.getLongIfDefined(json, KEY_EXPIRES_AT))
+                .setIdToken(JsonUtil.getStringIfDefined(json, KEY_ID_TOKEN))
+                .setRefreshToken(JsonUtil.getStringIfDefined(json, KEY_REFRESH_TOKEN))
+                .setScope(JsonUtil.getStringIfDefined(json, KEY_SCOPE))
+                .setAdditionalParameters(JsonUtil.getStringMap(json, KEY_ADDITIONAL_PARAMETERS))
                 .build();
     }
 

--- a/library/javatests/net/openid/appauth/RegistrationResponseTest.java
+++ b/library/javatests/net/openid/appauth/RegistrationResponseTest.java
@@ -131,6 +131,18 @@ public class RegistrationResponseTest {
         }
 
         @Test
+        public void testSerialization_doesNotChange() throws Exception {
+            mJson.put(RegistrationResponse.KEY_REQUEST,
+                getTestRegistrationRequest().jsonSerialize());
+            RegistrationResponse response = RegistrationResponse.jsonDeserialize(mJson);
+
+            String firstOutput = response.jsonSerializeString();
+            String secondOutput = RegistrationResponse.jsonDeserialize(mJson).jsonSerializeString();
+
+            assertThat(secondOutput).isEqualTo(firstOutput);
+        }
+
+        @Test
         public void testHasExpired_withValidClientSecret() throws Exception {
             RegistrationResponse response = RegistrationResponse
                     .fromJson(getTestRegistrationRequest(), mJson);
@@ -155,9 +167,6 @@ public class RegistrationResponseTest {
             assertThat(response.registrationClientUri)
                     .isEqualTo(Uri.parse(TEST_REGISTRATION_CLIENT_URI));
             assertThat(response.tokenEndpointAuthMethod).isEqualTo(TEST_TOKEN_ENDPOINT_AUTH_METHOD);
-            assertThat(response.additionalParameters)
-                    .containsEntry(RegistrationRequest.PARAM_APPLICATION_TYPE,
-                            RegistrationRequest.APPLICATION_TYPE_NATIVE);
         }
     }
 

--- a/library/javatests/net/openid/appauth/TokenResponseTest.java
+++ b/library/javatests/net/openid/appauth/TokenResponseTest.java
@@ -32,6 +32,9 @@ import static junit.framework.Assert.assertNull;
 import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
 import static net.openid.appauth.TestValues.TEST_AUTH_CODE;
 import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
+import static net.openid.appauth.TestValues.TEST_ID_TOKEN;
+import static net.openid.appauth.TestValues.TEST_REFRESH_TOKEN;
+import static net.openid.appauth.TestValues.TEST_SCOPE;
 import static net.openid.appauth.TestValues.getTestServiceConfig;
 import static net.openid.appauth.TokenResponse.KEY_ACCESS_TOKEN;
 import static net.openid.appauth.TokenResponse.KEY_EXPIRES_AT;
@@ -39,10 +42,10 @@ import static net.openid.appauth.TokenResponse.KEY_ID_TOKEN;
 import static net.openid.appauth.TokenResponse.KEY_REFRESH_TOKEN;
 import static net.openid.appauth.TokenResponse.KEY_SCOPE;
 import static net.openid.appauth.TokenResponse.KEY_TOKEN_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.junit.Assert.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk=16)
@@ -101,7 +104,6 @@ public class TokenResponseTest {
 
     @Test
     public void testBuilder_fromResponseJsonStringWithScope() throws JSONException{
-        System.out.println(TEST_JSON_WITH_SCOPE);
         TokenResponse tokenResponse = mMinimalBuilder.fromResponseJsonString(TEST_JSON_WITH_SCOPE).build();
 
         assertNotNull(tokenResponse);
@@ -113,12 +115,12 @@ public class TokenResponseTest {
         assertEquals(TEST_KEY_KEY_EXPIRES_AT, tokenResponse.accessTokenExpirationTime);
 
         assertEquals(TEST_KEY_SCOPES, tokenResponse.scope);
-        assertThat(tokenResponse.getScopeSet(), is(equalTo((Set) new HashSet<>(Arrays.asList(TEST_KEY_SCOPE_1, TEST_KEY_SCOPE_2, TEST_KEY_SCOPE_3)))));
+        assertThat(tokenResponse.getScopeSet()).isEqualTo(
+            new HashSet<>(Arrays.asList(TEST_KEY_SCOPE_1, TEST_KEY_SCOPE_2, TEST_KEY_SCOPE_3)));
     }
 
     @Test
     public void testBuilder_fromResponseJsonStringWithoutScope() throws JSONException{
-        System.out.println(TEST_JSON_WITHOUT_SCOPE);
         TokenResponse tokenResponse = mMinimalBuilder.fromResponseJsonString(TEST_JSON_WITHOUT_SCOPE).build();
 
         assertNotNull(tokenResponse);
@@ -129,13 +131,12 @@ public class TokenResponseTest {
         assertEquals(TEST_KEY_ID_TOKEN, tokenResponse.idToken);
         assertEquals(TEST_KEY_KEY_EXPIRES_AT, tokenResponse.accessTokenExpirationTime);
 
-        assertThat(tokenResponse.scope, isEmptyOrNullString());
+        assertThat(tokenResponse.scope).isNullOrEmpty();
         assertNull(tokenResponse.getScopeSet());
     }
 
     @Test
     public void testBuilder_fromResponseJsonStringWithoutScopeField() throws JSONException{
-        System.out.println(TEST_JSON_WITHOUT_SCOPE_FIELD);
         TokenResponse tokenResponse = mMinimalBuilder.fromResponseJsonString(TEST_JSON_WITHOUT_SCOPE_FIELD).build();
 
         assertNotNull(tokenResponse);
@@ -146,7 +147,39 @@ public class TokenResponseTest {
         assertEquals(TEST_KEY_ID_TOKEN, tokenResponse.idToken);
         assertEquals(TEST_KEY_KEY_EXPIRES_AT, tokenResponse.accessTokenExpirationTime);
 
-        assertThat(tokenResponse.scope, isEmptyOrNullString());
+        assertThat(tokenResponse.scope).isNullOrEmpty();
         assertNull(tokenResponse.getScopeSet());
+    }
+
+    @Test
+    public void testJsonSerialization() throws JSONException {
+        TokenResponse response = mMinimalBuilder
+            .setAccessToken(TEST_KEY_ACCESS_TOKEN)
+            .setAccessTokenExpirationTime(TEST_KEY_KEY_EXPIRES_AT)
+            .setIdToken(TEST_ID_TOKEN)
+            .setRefreshToken(TEST_REFRESH_TOKEN)
+            .setScope(TEST_SCOPE)
+            .setTokenType(TEST_KEY_TOKEN_TYPE)
+            .build();
+
+        String output = response.jsonSerializeString();
+        TokenResponse input = TokenResponse.jsonDeserialize(output);
+
+        assertThat(input.accessToken).isEqualTo(response.accessToken);
+        assertThat(input.accessTokenExpirationTime).isEqualTo(response.accessTokenExpirationTime);
+        assertThat(input.idToken).isEqualTo(response.idToken);
+        assertThat(input.refreshToken).isEqualTo(response.refreshToken);
+        assertThat(input.scope).isEqualTo(response.scope);
+        assertThat(input.tokenType).isEqualTo(response.tokenType);
+    }
+
+    @Test
+    public void testJsonSerialization_doesNotChange() throws Exception {
+        TokenResponse tokenResponse = mMinimalBuilder.fromResponseJsonString(TEST_JSON_WITH_SCOPE).build();
+
+        String firstOutput = tokenResponse.jsonSerializeString();
+        String secondOutput = TokenResponse.jsonDeserialize(firstOutput).jsonSerializeString();
+
+        assertThat(secondOutput).isEqualTo(firstOutput);
     }
 }


### PR DESCRIPTION
The deserialization for RegistrationResponse and TokenResponse was incorrectly copying the associated request into the "additionalParameters" map on each deserialize, resulting in exponential growth of the JSON with each subsequent serialize / deserialize operation.

Fixes #224, though clients will have to clear the additionalParameters map of unwanted properties manually, as I do not want to assume what properties are and are not being used in the map.