### PR TITLE
Throw JSONException if token_type field is missing from token response

### DIFF
--- a/library/java/net/openid/appauth/TokenResponse.java
+++ b/library/java/net/openid/appauth/TokenResponse.java
@@ -213,29 +213,20 @@ public class TokenResponse {
          */
         @NonNull
         public Builder fromResponseJson(@NonNull JSONObject json) throws JSONException {
-            try {
-                setTokenType(JsonUtil.getString(json, KEY_TOKEN_TYPE));
-                setAccessToken(JsonUtil.getStringIfDefined(json, KEY_ACCESS_TOKEN));
-                if (json.has(KEY_EXPIRES_AT)) {
-                    setAccessTokenExpirationTime(json.getLong(KEY_EXPIRES_AT));
-                }
-                if (json.has(KEY_EXPIRES_IN)) {
-                    setAccessTokenExpiresIn(json.getLong(KEY_EXPIRES_IN));
-                }
-                setRefreshToken(JsonUtil.getStringIfDefined(json, KEY_REFRESH_TOKEN));
-                setIdToken(JsonUtil.getStringIfDefined(json, KEY_ID_TOKEN));
-                setScope(JsonUtil.getStringIfDefined(json, KEY_SCOPE));
-                setAdditionalParameters(extractAdditionalParams(json, BUILT_IN_PARAMS));
-
-                return this;
-            } catch (JSONException ex) {
-                // JSONException should only be thrown if a get() call is made for a key which
-                // cannot be found. As all calls are guarded by has() calls, this exception should
-                // therefore not be thrown.
-                throw new IllegalStateException(
-                        "JSONException thrown in violation of contract",
-                        ex);
+            setTokenType(JsonUtil.getString(json, KEY_TOKEN_TYPE));
+            setAccessToken(JsonUtil.getStringIfDefined(json, KEY_ACCESS_TOKEN));
+            if (json.has(KEY_EXPIRES_AT)) {
+                setAccessTokenExpirationTime(json.getLong(KEY_EXPIRES_AT));
             }
+            if (json.has(KEY_EXPIRES_IN)) {
+                setAccessTokenExpiresIn(json.getLong(KEY_EXPIRES_IN));
+            }
+            setRefreshToken(JsonUtil.getStringIfDefined(json, KEY_REFRESH_TOKEN));
+            setIdToken(JsonUtil.getStringIfDefined(json, KEY_ID_TOKEN));
+            setScope(JsonUtil.getStringIfDefined(json, KEY_SCOPE));
+            setAdditionalParameters(extractAdditionalParams(json, BUILT_IN_PARAMS));
+
+            return this;
         }
 
         /**

--- a/library/javatests/net/openid/appauth/TokenResponseTest.java
+++ b/library/javatests/net/openid/appauth/TokenResponseTest.java
@@ -119,9 +119,9 @@ public class TokenResponseTest {
             new HashSet<>(Arrays.asList(TEST_KEY_SCOPE_1, TEST_KEY_SCOPE_2, TEST_KEY_SCOPE_3)));
     }
 
-    @Test
-    public void testBuilder_fromResponseJsonStringWithoutScope() throws JSONException{
-        TokenResponse tokenResponse = mMinimalBuilder.fromResponseJsonString(TEST_JSON_WITHOUT_SCOPE).build();
+    @Test(expected = JSONException.class)
+    public void testBuilder_fromResponseJsonString_emptyJson() throws JSONException{
+        TokenResponse tokenResponse = mMinimalBuilder.fromResponseJsonString("{}").build();
 
         assertNotNull(tokenResponse);
 


### PR DESCRIPTION
Error handling on the parsing of authorization and token responses generally
needs an overhaul to ensure we can more reliably catch data validation errors;
this just fixes one specific issue. Bigger changes will be deferred for the
0.7.0 release.

Fix for #228.