### PR TITLE
Actually write new AuthState to SharedPreferences

### DIFF
--- a/app/java/net/openid/appauthdemo/AuthStateManager.java
+++ b/app/java/net/openid/appauthdemo/AuthStateManager.java
@@ -151,10 +151,15 @@ public class AuthStateManager {
     private void writeState(@Nullable AuthState state) {
         mPrefsLock.lock();
         try {
+            SharedPreferences.Editor editor = mPrefs.edit();
             if (state == null) {
-                if (!mPrefs.edit().remove(KEY_STATE).commit()) {
-                    throw new IllegalStateException("Failed to write state to shared prefs");
-                }
+               editor.remove(KEY_STATE);
+            } else {
+                editor.putString(KEY_STATE, state.jsonSerializeString());
+            }
+            
+            if (!editor.commit()) {
+                throw new IllegalStateException("Failed to write state to shared prefs");
             }
         } finally {
             mPrefsLock.unlock();

--- a/app/java/net/openid/appauthdemo/AuthStateManager.java
+++ b/app/java/net/openid/appauthdemo/AuthStateManager.java
@@ -153,11 +153,11 @@ public class AuthStateManager {
         try {
             SharedPreferences.Editor editor = mPrefs.edit();
             if (state == null) {
-               editor.remove(KEY_STATE);
+                editor.remove(KEY_STATE);
             } else {
                 editor.putString(KEY_STATE, state.jsonSerializeString());
             }
-            
+
             if (!editor.commit()) {
                 throw new IllegalStateException("Failed to write state to shared prefs");
             }


### PR DESCRIPTION
The method writeState did not really write the state to the SharePreferences, but only removed the entry if the supplied state was null.