### PR TITLE
Fix minor gradle typo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ try {
     project.ext.versionName = grgit.describe()
     project.ext.versionDate = lastCommit.getDate()
     if (project.ext.versionName == null) {
-        project.ext.versionNme = 'DEV'
+        project.ext.versionName = 'DEV'
     }
 } catch (Exception ex) {
     project.ext.versionNum = 0


### PR DESCRIPTION
Fixes minor typo in `build.gradle` for a rare (if not impossible) error scenario. Just for correctness 😉 