### PR TITLE
Implement startActivityForResult based auth flow.

### DIFF
--- a/app/java/net/openid/appauthdemo/LoginActivity.java
+++ b/app/java/net/openid/appauthdemo/LoginActivity.java
@@ -37,6 +37,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -82,6 +83,7 @@ public final class LoginActivity extends AppCompatActivity {
 
     private static final String TAG = "LoginActivity";
     private static final String EXTRA_FAILED = "failed";
+    private static final int RC_AUTH = 100;
 
     private AuthorizationService mAuthService;
     private AuthStateManager mAuthStateManager;
@@ -92,6 +94,8 @@ public final class LoginActivity extends AppCompatActivity {
     private final AtomicReference<CustomTabsIntent> mAuthIntent = new AtomicReference<>();
     private CountDownLatch mAuthIntentLatch = new CountDownLatch(1);
     private ExecutorService mExecutor;
+
+    private boolean mUsePendingIntents;
 
     @NonNull
     private BrowserMatcher mBrowserMatcher = AnyBrowserMatcher.INSTANCE;
@@ -135,10 +139,7 @@ public final class LoginActivity extends AppCompatActivity {
         }
 
         if (getIntent().getBooleanExtra(EXTRA_FAILED, false)) {
-            Snackbar.make(findViewById(R.id.coordinator),
-                    "Authorization canceled",
-                    Snackbar.LENGTH_SHORT)
-                    .show();
+            displayAuthCancelled();
         }
 
         displayLoading("Initializing");
@@ -146,8 +147,8 @@ public final class LoginActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
+    protected void onResume() {
+        super.onResume();
         if (mExecutor.isShutdown()) {
             mExecutor = Executors.newSingleThreadExecutor();
         }
@@ -168,9 +169,23 @@ public final class LoginActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        displayAuthOptions();
+        if (resultCode == RESULT_CANCELED) {
+            displayAuthCancelled();
+        } else {
+            Intent intent = new Intent(this, TokenActivity.class);
+            intent.putExtras(data.getExtras());
+            startActivity(intent);
+        }
+    }
+
     @MainThread
     void startAuth() {
         displayLoading("Making authorization request");
+
+        mUsePendingIntents = ((CheckBox) findViewById(R.id.pending_intents_checkbox)).isChecked();
 
         // WrongThread inference is incorrect for lambdas
         // noinspection WrongThread
@@ -219,7 +234,8 @@ public final class LoginActivity extends AppCompatActivity {
 
     @MainThread
     private void handleConfigurationRetrievalResult(
-            AuthorizationServiceConfiguration config, AuthorizationException ex) {
+            AuthorizationServiceConfiguration config,
+            AuthorizationException ex) {
         if (config == null) {
             Log.i(TAG, "Failed to retrieve discovery document", ex);
             displayError("Failed to retrieve discovery document: " + ex.getMessage(), true);
@@ -330,16 +346,23 @@ public final class LoginActivity extends AppCompatActivity {
             Log.w(TAG, "Interrupted while waiting for auth intent");
         }
 
-        Intent completionIntent = new Intent(this, TokenActivity.class);
-        Intent cancelIntent = new Intent(this, LoginActivity.class);
-        cancelIntent.putExtra(EXTRA_FAILED, true);
-        cancelIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        if (mUsePendingIntents) {
+            Intent completionIntent = new Intent(this, TokenActivity.class);
+            Intent cancelIntent = new Intent(this, LoginActivity.class);
+            cancelIntent.putExtra(EXTRA_FAILED, true);
+            cancelIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
-        mAuthService.performAuthorizationRequest(
-                mAuthRequest.get(),
-                PendingIntent.getActivity(this, 0, completionIntent, 0),
-                PendingIntent.getActivity(this, 0, cancelIntent, 0),
-                mAuthIntent.get());
+            mAuthService.performAuthorizationRequest(
+                    mAuthRequest.get(),
+                    PendingIntent.getActivity(this, 0, completionIntent, 0),
+                    PendingIntent.getActivity(this, 0, cancelIntent, 0),
+                    mAuthIntent.get());
+        } else {
+            Intent intent = mAuthService.getAuthorizationRequestIntent(
+                    mAuthRequest.get(),
+                    mAuthIntent.get());
+            startActivityForResult(intent, RC_AUTH);
+        }
     }
 
     private void recreateAuthorizationService() {
@@ -422,6 +445,13 @@ public final class LoginActivity extends AppCompatActivity {
         ((TextView)findViewById(R.id.client_id)).setText(clientIdStr);
     }
 
+    private void displayAuthCancelled() {
+        Snackbar.make(findViewById(R.id.coordinator),
+            "Authorization canceled",
+            Snackbar.LENGTH_SHORT)
+            .show();
+    }
+
     private void warmUpBrowser() {
         mAuthIntentLatch = new CountDownLatch(1);
         mExecutor.execute(() -> {
@@ -452,9 +482,9 @@ public final class LoginActivity extends AppCompatActivity {
 
     private String getLoginHint() {
         return ((EditText)findViewById(R.id.login_hint_value))
-                .getText()
-                .toString()
-                .trim();
+            .getText()
+            .toString()
+            .trim();
     }
 
     @TargetApi(Build.VERSION_CODES.M)

--- a/app/java/net/openid/appauthdemo/LoginActivity.java
+++ b/app/java/net/openid/appauthdemo/LoginActivity.java
@@ -147,8 +147,8 @@ public final class LoginActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
+    protected void onStart() {
+        super.onStart();
         if (mExecutor.isShutdown()) {
             mExecutor = Executors.newSingleThreadExecutor();
         }
@@ -447,9 +447,9 @@ public final class LoginActivity extends AppCompatActivity {
 
     private void displayAuthCancelled() {
         Snackbar.make(findViewById(R.id.coordinator),
-            "Authorization canceled",
-            Snackbar.LENGTH_SHORT)
-            .show();
+                "Authorization canceled",
+                Snackbar.LENGTH_SHORT)
+                .show();
     }
 
     private void warmUpBrowser() {
@@ -482,9 +482,9 @@ public final class LoginActivity extends AppCompatActivity {
 
     private String getLoginHint() {
         return ((EditText)findViewById(R.id.login_hint_value))
-            .getText()
-            .toString()
-            .trim();
+                .getText()
+                .toString()
+                .trim();
     }
 
     @TargetApi(Build.VERSION_CODES.M)

--- a/app/res/layout/activity_login.xml
+++ b/app/res/layout/activity_login.xml
@@ -113,9 +113,15 @@
                     android:labelFor="@+id/browser_selector"/>
 
                 <Spinner
-                  android:id="@+id/browser_selector"
-                  android:layout_width="match_parent"
-                  android:layout_height="wrap_content" />
+                    android:id="@+id/browser_selector"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+                <CheckBox
+                    android:id="@+id/pending_intents_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/use_pending_intents"/>
 
 
                 <TextView

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="no_access_token_expiry">Access time has no defined expiry</string>
     <string name="access_token_expired">Access token has expired</string>
     <string name="auth_settings">Authorization settings in use:</string>
+    <string name="use_pending_intents">Use PendingIntent\'s for completion</string>
 </resources>

--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -42,32 +42,32 @@ import org.json.JSONException;
  *                          Back Stack Towards Top
  *                +------------------------------------------>
  *
- * +------------+       +---------------+      +----------------+      +--------------+
- * |            |  (1)  |               | (2)  |                | (S1) |              |
- * | Initiating +------>| Authorization +----->| Authorization  +----->| Redirect URI |
- * |  Activity  |       |  Management   |      |   Activity     |      |   Receiver   |
- * |            |<------+   Activity    |<-----+ (e.g. browser) |      |   Activity   |
- * |            | (C2b) |               | (C1) |                |      |              |
- * +------------+       +-+--+----------+      +----------------+      +-------+------+
- *                        |  |  ^                                              |
- *                        |  |  |                                              |
- *                +-------+  |  |                      (S2)                    |
- *                |          |  +----------------------------------------------+
- *                |          |
- *                |          v (S3)
- *          (C2a) |      +------------+
- *                |      |            |
- *                |      | Completion |
- *                |      |  Activity  |
- *                |      |            |
- *                |      +------------+
- *                |
- *                |      +-------------+
- *                |      |             |
- *                +----->| Cancelation |
- *                       |  Activity   |
- *                       |             |
- *                       +-------------+
+ * +------------+            +---------------+      +----------------+      +--------------+
+ * |            |     (1)    |               | (2)  |                | (S1) |              |
+ * | Initiating +----------->| Authorization +----->| Authorization  +----->| Redirect URI |
+ * |  Activity  |            |  Management   |      |   Activity     |      |   Receiver   |
+ * |            |<-----------+   Activity    |<-----+ (e.g. browser) |      |   Activity   |
+ * |            | (C2b, S3b) |               | (C1) |                |      |              |
+ * +------------+            +-+---+---------+      +----------------+      +-------+------+
+ *                           |  |  ^                                              |
+ *                           |  |  |                                              |
+ *                   +-------+  |  |                      (S2)                    |
+ *                   |          |  +----------------------------------------------+
+ *                   |          |
+ *                   |          v (S3a)
+ *             (C2a) |      +------------+
+ *                   |      |            |
+ *                   |      | Completion |
+ *                   |      |  Activity  |
+ *                   |      |            |
+ *                   |      +------------+
+ *                   |
+ *                   |      +-------------+
+ *                   |      |             |
+ *                   +----->| Cancelation |
+ *                          |  Activity   |
+ *                          |             |
+ *                          +-------------+
  * ```
  *
  * The process begins with an activity requesting that an authorization flow be started,
@@ -88,7 +88,9 @@ import org.json.JSONException;
  *       {@link AuthorizationService#performAuthorizationRequest}, then this is
  *       used to invoke a cancelation activity.
  *
- *     - Step C2b: If no cancellation PendingIntent was provided (legacy behavior), then the
+ *     - Step C2b: If no cancellation PendingIntent was provided (legacy behavior, or
+ *       AuthorizationManagementActivity was started with an intent from
+ *       {@link AuthorizationService#getAuthorizationRequestIntent}), then the
  *       AuthorizationManagementActivity simply finishes after calling {@link Activity#setResult},
  *       with {@link Activity#RESULT_CANCELED}, returning control to the activity above
  *       it in the back stack (typically, the initiating activity).

--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -299,8 +299,8 @@ public class AuthorizationManagementActivity extends Activity {
         try {
             String authRequestJson = state.getString(KEY_AUTH_REQUEST, null);
             mAuthRequest = authRequestJson != null
-                ? AuthorizationRequest.jsonDeserialize(authRequestJson)
-                : null;
+                    ? AuthorizationRequest.jsonDeserialize(authRequestJson)
+                    : null;
         } catch (JSONException ex) {
             throw new IllegalStateException("Unable to deserialize authorization request", ex);
         }
@@ -317,8 +317,7 @@ public class AuthorizationManagementActivity extends Activity {
                     .build();
 
             if (mAuthRequest.state == null && response.state != null
-                    || (mAuthRequest.state != null
-                    && !mAuthRequest.state.equals(response.state))) {
+                    || (mAuthRequest.state != null && !mAuthRequest.state.equals(response.state))) {
 
                 Logger.warn("State returned in authorization response (%s) does not match state "
                         + "from request (%s) - discarding response",

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -224,10 +224,7 @@ public class AuthorizationService {
 
     /**
      * Constructs an intent that encapsulates the provided request and custom tabs intent,
-     * and is intended to be launched via {@link Activity#startActivityForResult}
-     * When started, the intent launches an {@link Activity} that sends an authorization request
-     * to the authorization service, using a
-     * [custom tab](https://developer.chrome.com/multidevice/android/customtabs).
+     * and is intended to be launched via {@link Activity#startActivityForResult}.
      * The parameters of this request are determined by both the authorization service
      * configuration and the provided {@link AuthorizationRequest request object}. Upon completion
      * of this request, the activity that gets launched will call {@link Activity#setResult} with

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -31,6 +31,7 @@ import android.text.TextUtils;
 import net.openid.appauth.AuthorizationException.GeneralErrors;
 import net.openid.appauth.AuthorizationException.RegistrationRequestErrors;
 import net.openid.appauth.AuthorizationException.TokenRequestErrors;
+
 import net.openid.appauth.browser.BrowserDescriptor;
 import net.openid.appauth.browser.BrowserSelector;
 import net.openid.appauth.browser.CustomTabManager;
@@ -88,11 +89,11 @@ public class AuthorizationService {
             @NonNull Context context,
             @NonNull AppAuthConfiguration clientConfiguration) {
         this(context,
-            clientConfiguration,
-            BrowserSelector.select(
-                context,
-                clientConfiguration.getBrowserMatcher()),
-            new CustomTabManager(context));
+                clientConfiguration,
+                BrowserSelector.select(
+                        context,
+                        clientConfiguration.getBrowserMatcher()),
+                new CustomTabManager(context));
     }
 
     /**
@@ -100,9 +101,9 @@ public class AuthorizationService {
      */
     @VisibleForTesting
     AuthorizationService(@NonNull Context context,
-            @NonNull AppAuthConfiguration clientConfiguration,
-            @Nullable BrowserDescriptor browser,
-            @NonNull CustomTabManager customTabManager) {
+                         @NonNull AppAuthConfiguration clientConfiguration,
+                         @Nullable BrowserDescriptor browser,
+                         @NonNull CustomTabManager customTabManager) {
         mContext = checkNotNull(context);
         mClientConfiguration = clientConfiguration;
         mCustomTabManager = customTabManager;
@@ -251,9 +252,9 @@ public class AuthorizationService {
 
         Intent authIntent = prepareAuthorizationRequestIntent(request, customTabsIntent);
         return AuthorizationManagementActivity.createStartForResultIntent(
-            mContext,
-            request,
-            authIntent);
+                mContext,
+                request,
+                authIntent);
     }
 
     /**
@@ -377,10 +378,9 @@ public class AuthorizationService {
 
         private AuthorizationException mException;
 
-        TokenRequestTask(
-                TokenRequest request,
-                @NonNull ClientAuthentication clientAuthentication,
-                TokenResponseCallback callback) {
+        TokenRequestTask(TokenRequest request,
+                         @NonNull ClientAuthentication clientAuthentication,
+                         TokenResponseCallback callback) {
             mRequest = request;
             mCallback = callback;
             mClientAuthentication = clientAuthentication;
@@ -392,7 +392,7 @@ public class AuthorizationService {
             try {
                 HttpURLConnection conn =
                         mClientConfiguration.getConnectionBuilder()
-                            .openConnection(mRequest.configuration.tokenEndpoint);
+                                .openConnection(mRequest.configuration.tokenEndpoint);
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
                 addJsonToAcceptHeader(conn);
@@ -431,11 +431,11 @@ public class AuthorizationService {
             } catch (IOException ex) {
                 Logger.debugWithStack(ex, "Failed to complete exchange request");
                 mException = AuthorizationException.fromTemplate(
-                    GeneralErrors.NETWORK_ERROR, ex);
+                        GeneralErrors.NETWORK_ERROR, ex);
             } catch (JSONException ex) {
                 Logger.debugWithStack(ex, "Failed to complete exchange request");
                 mException = AuthorizationException.fromTemplate(
-                    GeneralErrors.JSON_DESERIALIZATION_ERROR, ex);
+                        GeneralErrors.JSON_DESERIALIZATION_ERROR, ex);
             } finally {
                 Utils.closeQuietly(is);
             }
@@ -458,7 +458,7 @@ public class AuthorizationService {
                             error,
                             json.optString(AuthorizationException.PARAM_ERROR_DESCRIPTION, null),
                             UriUtil.parseUriIfAvailable(
-                                json.optString(AuthorizationException.PARAM_ERROR_URI)));
+                                    json.optString(AuthorizationException.PARAM_ERROR_URI)));
                 } catch (JSONException jsonEx) {
                     ex = AuthorizationException.fromTemplate(
                             GeneralErrors.JSON_DESERIALIZATION_ERROR,
@@ -474,8 +474,8 @@ public class AuthorizationService {
             } catch (JSONException jsonEx) {
                 mCallback.onTokenRequestCompleted(null,
                         AuthorizationException.fromTemplate(
-                            GeneralErrors.JSON_DESERIALIZATION_ERROR,
-                            jsonEx));
+                                GeneralErrors.JSON_DESERIALIZATION_ERROR,
+                                jsonEx));
                 return;
             }
 
@@ -515,8 +515,7 @@ public class AuthorizationService {
          *
          * @see AuthorizationException.TokenRequestErrors
          */
-        void onTokenRequestCompleted(
-                @Nullable TokenResponse response,
+        void onTokenRequestCompleted(@Nullable TokenResponse response,
                 @Nullable AuthorizationException ex);
     }
 
@@ -527,8 +526,7 @@ public class AuthorizationService {
 
         private AuthorizationException mException;
 
-        RegistrationRequestTask(
-                RegistrationRequest request,
+        RegistrationRequestTask(RegistrationRequest request,
                 RegistrationResponseCallback callback) {
             mRequest = request;
             mCallback = callback;
@@ -541,7 +539,7 @@ public class AuthorizationService {
             try {
                 HttpURLConnection conn =
                         mClientConfiguration.getConnectionBuilder()
-                            .openConnection(mRequest.configuration.registrationEndpoint);
+                                .openConnection(mRequest.configuration.registrationEndpoint);
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Content-Type", "application/json");
                 conn.setDoOutput(true);
@@ -583,7 +581,7 @@ public class AuthorizationService {
                             error,
                             json.getString(AuthorizationException.PARAM_ERROR_DESCRIPTION),
                             UriUtil.parseUriIfAvailable(
-                                json.getString(AuthorizationException.PARAM_ERROR_URI)));
+                                    json.getString(AuthorizationException.PARAM_ERROR_URI)));
                 } catch (JSONException jsonEx) {
                     ex = AuthorizationException.fromTemplate(
                             GeneralErrors.JSON_DESERIALIZATION_ERROR,
@@ -600,8 +598,8 @@ public class AuthorizationService {
             } catch (JSONException jsonEx) {
                 mCallback.onRegistrationRequestCompleted(null,
                         AuthorizationException.fromTemplate(
-                            GeneralErrors.JSON_DESERIALIZATION_ERROR,
-                            jsonEx));
+                                GeneralErrors.JSON_DESERIALIZATION_ERROR,
+                                jsonEx));
                 return;
             } catch (RegistrationResponse.MissingArgumentException ex) {
                 Logger.errorWithStack(ex, "Malformed registration response");
@@ -634,8 +632,7 @@ public class AuthorizationService {
          * @param ex a description of the failure, if one occurred: `null` otherwise.
          * @see AuthorizationException.RegistrationRequestErrors
          */
-        void onRegistrationRequestCompleted(
-                @Nullable RegistrationResponse response,
-                @Nullable AuthorizationException ex);
+        void onRegistrationRequestCompleted(@Nullable RegistrationResponse response,
+                                            @Nullable AuthorizationException ex);
     }
 }

--- a/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
@@ -14,6 +14,8 @@
 
 package net.openid.appauth;
 
+import static android.app.Activity.RESULT_CANCELED;
+import static android.app.Activity.RESULT_OK;
 import static org.assertj.android.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
@@ -44,8 +46,9 @@ public class AuthorizationManagementActivityTest {
     private PendingIntent mCompletePendingIntent;
     private Intent mCancelIntent;
     private PendingIntent mCancelPendingIntent;
-    private Intent mStartIntent;
-    private Intent mStartIntentWithoutCancel;
+    private Intent mStartIntentWithPendings;
+    private Intent mStartIntentWithPendingsWithoutCancel;
+    private Intent mStartForResultIntent;
     private ActivityController<AuthorizationManagementActivity> mController;
     private AuthorizationManagementActivity mActivity;
     private ShadowActivity mActivityShadow;
@@ -59,54 +62,65 @@ public class AuthorizationManagementActivityTest {
         mAuthIntent = new Intent("AUTH");
         mCompleteIntent = new Intent("COMPLETE");
         mCompletePendingIntent =
-                PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCompleteIntent, 0);
+            PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCompleteIntent, 0);
         mCancelIntent = new Intent("CANCEL");
         mCancelPendingIntent =
-                PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCancelIntent, 0);
+            PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCancelIntent, 0);
 
-        mStartIntent = createStartIntent(mAuthRequest, mCancelPendingIntent);
-        mStartIntentWithoutCancel = createStartIntent(mAuthRequest, null);
+        mStartIntentWithPendings =
+            createStartIntentWithPendingIntents(mAuthRequest, mCancelPendingIntent);
+        mStartIntentWithPendingsWithoutCancel =
+            createStartIntentWithPendingIntents(mAuthRequest, null);
+        mStartForResultIntent = createStartForResultIntent(mAuthRequest);
 
         mSuccessAuthRedirect = mAuthRequest.redirectUri.buildUpon()
-                .appendQueryParameter(AuthorizationResponse.KEY_STATE, mAuthRequest.state)
-                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-                .build();
+            .appendQueryParameter(AuthorizationResponse.KEY_STATE, mAuthRequest.state)
+            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+            .build();
 
         mErrorAuthRedirect = mAuthRequest.redirectUri.buildUpon()
-                .appendQueryParameter(
-                        AuthorizationException.PARAM_ERROR,
-                        AuthorizationRequestErrors.ACCESS_DENIED.error)
-                .appendQueryParameter(
-                        AuthorizationException.PARAM_ERROR_DESCRIPTION,
-                        AuthorizationRequestErrors.ACCESS_DENIED.errorDescription)
-                .build();
+            .appendQueryParameter(
+                AuthorizationException.PARAM_ERROR,
+                AuthorizationRequestErrors.ACCESS_DENIED.error)
+            .appendQueryParameter(
+                AuthorizationException.PARAM_ERROR_DESCRIPTION,
+                AuthorizationRequestErrors.ACCESS_DENIED.errorDescription)
+            .build();
 
-        instantiateActivity(mStartIntent);
+        instantiateActivity(mStartIntentWithPendings);
     }
 
-    private Intent createStartIntent(
-            AuthorizationRequest authRequest,
-            PendingIntent cancelIntent) {
+    private Intent createStartIntentWithPendingIntents(
+        AuthorizationRequest authRequest,
+        PendingIntent cancelIntent) {
         return AuthorizationManagementActivity.createStartIntent(
-                RuntimeEnvironment.application,
-                authRequest,
-                mAuthIntent,
-                mCompletePendingIntent,
-                cancelIntent);
+            RuntimeEnvironment.application,
+            authRequest,
+            mAuthIntent,
+            mCompletePendingIntent,
+            cancelIntent);
+    }
+
+    private Intent createStartForResultIntent(
+        AuthorizationRequest authRequest) {
+        return AuthorizationManagementActivity.createStartForResultIntent(
+            RuntimeEnvironment.application,
+            authRequest,
+            mAuthIntent);
     }
 
     private void instantiateActivity(Intent managementIntent) {
         mController = Robolectric.buildActivity(AuthorizationManagementActivity.class)
-                .withIntent(managementIntent);
+            .withIntent(managementIntent);
 
         mActivity = mController.get();
         mActivityShadow = shadowOf(mActivity);
     }
 
     @Test
-    public void testSuccessFlow_withoutDestroy() {
+    public void testSuccessFlow_withPendingIntentsAndWithoutDestroy_shouldSendCompleteIntent() {
         // start the flow
-        instantiateActivity(mStartIntent);
+        instantiateActivity(mStartIntentWithPendings);
         mController.create().start().resume();
 
         // an activity should be started for auth
@@ -119,24 +133,51 @@ public class AuthorizationManagementActivityTest {
         // on completion of the authorization activity, the result will be forwarded to the
         // management activity via newIntent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-                RuntimeEnvironment.application,
-                mSuccessAuthRedirect));
+            RuntimeEnvironment.application,
+            mSuccessAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
 
         // after which the completion intent should be fired
         assertThat(mActivityShadow.getNextStartedActivity())
-                .hasAction("COMPLETE")
-                .hasData(mSuccessAuthRedirect)
-                .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
+            .hasAction("COMPLETE")
+            .hasData(mSuccessAuthRedirect)
+            .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
         assertThat(mActivity).isFinishing();
     }
 
     @Test
-    public void testSuccessFlow_withDestroy() {
+    public void testSuccessFlow_withoutPendingIntentsAndWithoutDestroy_shouldSetResult() {
         // start the flow
-        instantiateActivity(mStartIntent);
+        instantiateActivity(mStartForResultIntent);
+        mController.create().start().resume();
+
+        // an activity should be started for auth
+        assertThat(mActivityShadow.getNextStartedActivity()).hasAction("AUTH");
+
+        // the management activity will be paused while the authorization flow is running.
+        // if there is no memory pressure, the activity will remain in the paused state.
+        mController.pause();
+
+        // on completion of the authorization activity, the result will be forwarded to the
+        // management activity via newIntent
+        mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
+            RuntimeEnvironment.application,
+            mSuccessAuthRedirect));
+
+        // the management activity is then resumed
+        mController.resume();
+
+        // and then sets a result before finishing as there is no completion intent
+        assertThat(mActivityShadow.getResultCode()).isEqualTo(RESULT_OK);
+        assertThat(mActivity).isFinishing();
+    }
+
+    @Test
+    public void testSuccessFlow_withPendingIntentsAndWithDestroy_shouldSendCompleteIntent() {
+        // start the flow
+        instantiateActivity(mStartIntentWithPendings);
         mController.create().start().resume();
 
         // an activity should be started for auth
@@ -148,29 +189,60 @@ public class AuthorizationManagementActivityTest {
         mController.pause().stop().saveInstanceState(savedState).destroy();
 
         // on completion of the authorization activity, a new management activity will be created
-        instantiateActivity(mStartIntent);
+        instantiateActivity(mStartIntentWithPendings);
         mController.create(savedState).start();
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-                RuntimeEnvironment.application,
-                mSuccessAuthRedirect));
+            RuntimeEnvironment.application,
+            mSuccessAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
 
         // after which the completion intent should be fired
         assertThat(mActivityShadow.getNextStartedActivity())
-                .hasAction("COMPLETE")
-                .hasData(mSuccessAuthRedirect)
-                .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
+            .hasAction("COMPLETE")
+            .hasData(mSuccessAuthRedirect)
+            .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
         assertThat(mActivity).isFinishing();
     }
 
     @Test
-    public void testFailureFlow_withoutDestroy() {
+    public void testSuccessFlow_withoutPendingIntentsAndWithDestroy_shouldSetResult() {
         // start the flow
-        instantiateActivity(mStartIntent);
+        instantiateActivity(mStartForResultIntent);
+        mController.create().start().resume();
+
+        // an activity should be started for auth
+        assertThat(mActivityShadow.getNextStartedActivity()).hasAction("AUTH");
+
+        // on a device under memory pressure, the management activity will be destroyed, but
+        // it will be able to save its state
+        Bundle savedState = new Bundle();
+        mController.pause().stop().saveInstanceState(savedState).destroy();
+
+        // on completion of the authorization activity, a new management activity will be created
+        instantiateActivity(mStartIntentWithPendings);
+        mController.create(savedState).start();
+
+        // the authorization redirect will be forwarded via a new intent
+        mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
+            RuntimeEnvironment.application,
+            mSuccessAuthRedirect));
+
+        // the management activity is then resumed
+        mController.resume();
+
+        // and then sets a result before finishing as there is no completion intent
+        assertThat(mActivityShadow.getResultCode()).isEqualTo(RESULT_OK);
+        assertThat(mActivity).isFinishing();
+    }
+
+    @Test
+    public void testFailureFlow_withPendingIntentsAndWithoutDestroy_shouldSendCompleteIntent() {
+        // start the flow
+        instantiateActivity(mStartIntentWithPendings);
         mController.create().start().resume();
 
         // an activity should be started for auth
@@ -182,85 +254,174 @@ public class AuthorizationManagementActivityTest {
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-                RuntimeEnvironment.application,
-                mErrorAuthRedirect));
+            RuntimeEnvironment.application,
+            mErrorAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
 
         // after which the completion intent should be fired
         assertThat(mActivityShadow.getNextStartedActivity())
-                .hasAction("COMPLETE")
-                .hasData(mErrorAuthRedirect)
-                .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+            .hasAction("COMPLETE")
+            .hasData(mErrorAuthRedirect)
+            .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
         assertThat(mActivity).isFinishing();
     }
 
     @Test
-    public void testMismatchedState_responseDiffersFromRequest() {
-        emulateFlowToAuthorizationActivityLaunch(mStartIntent);
+    public void testFailureFlow_withoutPendingIntentsAndWithoutDestroy_shouldSetResult() {
+        // start the flow
+        instantiateActivity(mStartForResultIntent);
+        mController.create().start().resume();
 
-        Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-                .build();
+        // an activity should be started for auth
+        assertThat(mActivityShadow.getNextStartedActivity()).hasAction("AUTH");
 
-        Intent nextStartedActivity = emulateAuthorizationResponseReceived(
-                AuthorizationManagementActivity.createResponseHandlingIntent(
-                        RuntimeEnvironment.application,
-                        authResponseUri));
+        // the management activity will be paused while the authorization flow is running.
+        // if there is no memory pressure, the activity will remain in the paused state.
+        mController.pause();
 
-        // the next activity should be from the completion intent, carrying an error
-        assertThat(nextStartedActivity)
-                .hasAction("COMPLETE")
-                .hasData(authResponseUri)
-                .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+        // the authorization redirect will be forwarded via a new intent
+        mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
+            RuntimeEnvironment.application,
+            mErrorAuthRedirect));
 
-        assertThat(AuthorizationException.fromIntent(nextStartedActivity))
-                .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+        // the management activity is then resumed
+        mController.resume();
+
+        // after which the completion intent should be fired
+        assertThat(mActivityShadow.getResultCode()).isEqualTo(RESULT_OK);
+        Intent resultIntent = mActivityShadow.getResultIntent();
+        assertThat(resultIntent.getData()).isEqualTo(mErrorAuthRedirect);
+        assertThat(mActivity).isFinishing();
     }
 
     @Test
-    public void testMismatchedState_noStateInRequestWithStateInResponse() {
-        AuthorizationRequest request = new AuthorizationRequest.Builder(
-                TestValues.getTestServiceConfig(),
-                TestValues.TEST_CLIENT_ID,
-                ResponseTypeValues.CODE,
-                TestValues.TEST_APP_REDIRECT_URI)
-                .setState(null)
-                .build();
-
-        emulateFlowToAuthorizationActivityLaunch(createStartIntent(request, mCancelPendingIntent));
+    public void testMismatchedState_withPendingIntentsAndResponseDiffersFromRequest() {
+        emulateFlowToAuthorizationActivityLaunch(mStartIntentWithPendings);
 
         Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-                .build();
+            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+            .build();
+
+        Intent nextStartedActivity = emulateAuthorizationResponseReceived(
+            AuthorizationManagementActivity.createResponseHandlingIntent(
+                RuntimeEnvironment.application,
+                authResponseUri));
+
+        // the next activity should be from the completion intent, carrying an error
+        assertThat(nextStartedActivity)
+            .hasAction("COMPLETE")
+            .hasData(authResponseUri)
+            .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+
+        assertThat(AuthorizationException.fromIntent(nextStartedActivity))
+            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+    }
+
+    @Test
+    public void testMismatchedState_withoutPendingIntentsAndResponseDiffersFromRequest() {
+        emulateFlowToAuthorizationActivityLaunch(mStartForResultIntent);
+
+        Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
+            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+            .build();
+
+        // the authorization redirect will be forwarded via a new intent
+        mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
+            RuntimeEnvironment.application,
+            authResponseUri));
+
+        // the management activity is then resumed
+        mController.resume();
+
+        // no completion intent, so exception should be passed to calling activity
+        // via the result intent supplied to setResult
+        Intent resultIntent = mActivityShadow.getResultIntent();
+
+        assertThat(resultIntent)
+            .hasData(authResponseUri)
+            .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+
+        assertThat(AuthorizationException.fromIntent(resultIntent))
+            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+    }
+
+    @Test
+    public void testMismatchedState_withPendingIntentsAndNoStateInRequestWithStateInResponse() {
+        AuthorizationRequest request = new AuthorizationRequest.Builder(
+            TestValues.getTestServiceConfig(),
+            TestValues.TEST_CLIENT_ID,
+            ResponseTypeValues.CODE,
+            TestValues.TEST_APP_REDIRECT_URI)
+            .setState(null)
+            .build();
+
+        Intent startIntent = createStartIntentWithPendingIntents(request, mCancelPendingIntent);
+        emulateFlowToAuthorizationActivityLaunch(startIntent);
+
+        Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
+            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+            .build();
 
         // the next activity should be from the completion intent, carrying an error
         Intent nextStartedActivity = emulateAuthorizationResponseReceived(
-                AuthorizationManagementActivity.createResponseHandlingIntent(
-                        RuntimeEnvironment.application,
-                        authResponseUri));
+            AuthorizationManagementActivity.createResponseHandlingIntent(
+                RuntimeEnvironment.application,
+                authResponseUri));
 
         assertThat(AuthorizationException.fromIntent(nextStartedActivity))
-                .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+    }
+
+    @Test
+    public void testMismatchedState_withoutPendingIntentsAndNoStateInRequestWithStateInResponse() {
+        AuthorizationRequest request = new AuthorizationRequest.Builder(
+            TestValues.getTestServiceConfig(),
+            TestValues.TEST_CLIENT_ID,
+            ResponseTypeValues.CODE,
+            TestValues.TEST_APP_REDIRECT_URI)
+            .setState(null)
+            .build();
+
+        Intent startIntent = createStartForResultIntent(request);
+        emulateFlowToAuthorizationActivityLaunch(startIntent);
+
+        Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
+            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+            .build();
+
+        // the authorization redirect will be forwarded via a new intent
+        mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
+            RuntimeEnvironment.application,
+            authResponseUri));
+
+        // the management activity is then resumed
+        mController.resume();
+
+        Intent resultIntent = mActivityShadow.getResultIntent();
+        assertThat(AuthorizationException.fromIntent(resultIntent))
+            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
     }
 
     @Test
     public void testInvalidResponse() {
-        emulateFlowToAuthorizationActivityLaunch(mStartIntent);
+        emulateFlowToAuthorizationActivityLaunch(mStartIntentWithPendings);
 
         Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-                .build();
+            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+            .build();
     }
 
     @Test
-    public void testCancelFlow_withoutDestroy() {
+    public void testCancelFlow_withPendingIntentsAndWithoutDestroy() {
         // start the flow
-        instantiateActivity(mStartIntent);
+        instantiateActivity(mStartIntentWithPendings);
         mController.create().start().resume();
 
         // an activity should be started for auth
@@ -278,9 +439,29 @@ public class AuthorizationManagementActivityTest {
     }
 
     @Test
-    public void testCancelFlow_noCancelIntent() {
+    public void testCancelFlow_withoutPendingIntentsAndWithoutDestroy() {
         // start the flow
-        instantiateActivity(mStartIntentWithoutCancel);
+        instantiateActivity(mStartForResultIntent);
+        mController.create().start().resume();
+
+        // an activity should be started for auth
+        assertThat(mActivityShadow.getNextStartedActivity()).isNotNull();
+
+        // the management activity will be paused while this auth intent is running
+        mController.pause();
+
+        // when the user cancels the auth intent, the management activity will be resumed
+        mController.resume();
+
+        // at which point the cancel intent should be fired
+        assertThat(mActivityShadow.getResultCode()).isEqualTo(RESULT_CANCELED);
+        assertThat(mActivity).isFinishing();
+    }
+
+    @Test
+    public void testCancelFlow_withCompletionIntentButNoCancelIntent() {
+        // start the flow
+        instantiateActivity(mStartIntentWithPendingsWithoutCancel);
         mController.create().start().resume();
 
         // an activity should be started for auth
@@ -299,7 +480,7 @@ public class AuthorizationManagementActivityTest {
 
     private void emulateFlowToAuthorizationActivityLaunch(Intent startIntent) {
         // start the flow
-        instantiateActivity(mStartIntent);
+        instantiateActivity(startIntent);
         mController.create().start().resume();
 
         // an activity should be started for auth

--- a/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
@@ -80,11 +80,11 @@ public class AuthorizationManagementActivityTest {
 
         mErrorAuthRedirect = mAuthRequest.redirectUri.buildUpon()
                 .appendQueryParameter(
-                    AuthorizationException.PARAM_ERROR,
-                    AuthorizationRequestErrors.ACCESS_DENIED.error)
+                        AuthorizationException.PARAM_ERROR,
+                        AuthorizationRequestErrors.ACCESS_DENIED.error)
                 .appendQueryParameter(
-                    AuthorizationException.PARAM_ERROR_DESCRIPTION,
-                    AuthorizationRequestErrors.ACCESS_DENIED.errorDescription)
+                        AuthorizationException.PARAM_ERROR_DESCRIPTION,
+                        AuthorizationRequestErrors.ACCESS_DENIED.errorDescription)
                 .build();
 
         instantiateActivity(mStartIntentWithPendings);

--- a/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
@@ -62,56 +62,56 @@ public class AuthorizationManagementActivityTest {
         mAuthIntent = new Intent("AUTH");
         mCompleteIntent = new Intent("COMPLETE");
         mCompletePendingIntent =
-            PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCompleteIntent, 0);
+                PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCompleteIntent, 0);
         mCancelIntent = new Intent("CANCEL");
         mCancelPendingIntent =
-            PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCancelIntent, 0);
+                PendingIntent.getActivity(RuntimeEnvironment.application, 0, mCancelIntent, 0);
 
         mStartIntentWithPendings =
-            createStartIntentWithPendingIntents(mAuthRequest, mCancelPendingIntent);
+                createStartIntentWithPendingIntents(mAuthRequest, mCancelPendingIntent);
         mStartIntentWithPendingsWithoutCancel =
-            createStartIntentWithPendingIntents(mAuthRequest, null);
+                createStartIntentWithPendingIntents(mAuthRequest, null);
         mStartForResultIntent = createStartForResultIntent(mAuthRequest);
 
         mSuccessAuthRedirect = mAuthRequest.redirectUri.buildUpon()
-            .appendQueryParameter(AuthorizationResponse.KEY_STATE, mAuthRequest.state)
-            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-            .build();
+                .appendQueryParameter(AuthorizationResponse.KEY_STATE, mAuthRequest.state)
+                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+                .build();
 
         mErrorAuthRedirect = mAuthRequest.redirectUri.buildUpon()
-            .appendQueryParameter(
-                AuthorizationException.PARAM_ERROR,
-                AuthorizationRequestErrors.ACCESS_DENIED.error)
-            .appendQueryParameter(
-                AuthorizationException.PARAM_ERROR_DESCRIPTION,
-                AuthorizationRequestErrors.ACCESS_DENIED.errorDescription)
-            .build();
+                .appendQueryParameter(
+                    AuthorizationException.PARAM_ERROR,
+                    AuthorizationRequestErrors.ACCESS_DENIED.error)
+                .appendQueryParameter(
+                    AuthorizationException.PARAM_ERROR_DESCRIPTION,
+                    AuthorizationRequestErrors.ACCESS_DENIED.errorDescription)
+                .build();
 
         instantiateActivity(mStartIntentWithPendings);
     }
 
     private Intent createStartIntentWithPendingIntents(
-        AuthorizationRequest authRequest,
-        PendingIntent cancelIntent) {
+            AuthorizationRequest authRequest,
+            PendingIntent cancelIntent) {
         return AuthorizationManagementActivity.createStartIntent(
-            RuntimeEnvironment.application,
-            authRequest,
-            mAuthIntent,
-            mCompletePendingIntent,
-            cancelIntent);
+                RuntimeEnvironment.application,
+                authRequest,
+                mAuthIntent,
+                mCompletePendingIntent,
+                cancelIntent);
     }
 
     private Intent createStartForResultIntent(
-        AuthorizationRequest authRequest) {
+            AuthorizationRequest authRequest) {
         return AuthorizationManagementActivity.createStartForResultIntent(
-            RuntimeEnvironment.application,
-            authRequest,
-            mAuthIntent);
+                RuntimeEnvironment.application,
+                authRequest,
+                mAuthIntent);
     }
 
     private void instantiateActivity(Intent managementIntent) {
         mController = Robolectric.buildActivity(AuthorizationManagementActivity.class)
-            .withIntent(managementIntent);
+                .withIntent(managementIntent);
 
         mActivity = mController.get();
         mActivityShadow = shadowOf(mActivity);
@@ -133,17 +133,17 @@ public class AuthorizationManagementActivityTest {
         // on completion of the authorization activity, the result will be forwarded to the
         // management activity via newIntent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            mSuccessAuthRedirect));
+                RuntimeEnvironment.application,
+                mSuccessAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
 
         // after which the completion intent should be fired
         assertThat(mActivityShadow.getNextStartedActivity())
-            .hasAction("COMPLETE")
-            .hasData(mSuccessAuthRedirect)
-            .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
+                .hasAction("COMPLETE")
+                .hasData(mSuccessAuthRedirect)
+                .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
         assertThat(mActivity).isFinishing();
     }
 
@@ -163,8 +163,8 @@ public class AuthorizationManagementActivityTest {
         // on completion of the authorization activity, the result will be forwarded to the
         // management activity via newIntent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            mSuccessAuthRedirect));
+                RuntimeEnvironment.application,
+                mSuccessAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
@@ -194,17 +194,17 @@ public class AuthorizationManagementActivityTest {
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            mSuccessAuthRedirect));
+                RuntimeEnvironment.application,
+                mSuccessAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
 
         // after which the completion intent should be fired
         assertThat(mActivityShadow.getNextStartedActivity())
-            .hasAction("COMPLETE")
-            .hasData(mSuccessAuthRedirect)
-            .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
+                .hasAction("COMPLETE")
+                .hasData(mSuccessAuthRedirect)
+                .hasExtra(AuthorizationResponse.EXTRA_RESPONSE);
         assertThat(mActivity).isFinishing();
     }
 
@@ -228,8 +228,8 @@ public class AuthorizationManagementActivityTest {
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            mSuccessAuthRedirect));
+                RuntimeEnvironment.application,
+                mSuccessAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
@@ -254,17 +254,17 @@ public class AuthorizationManagementActivityTest {
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            mErrorAuthRedirect));
+                RuntimeEnvironment.application,
+                mErrorAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
 
         // after which the completion intent should be fired
         assertThat(mActivityShadow.getNextStartedActivity())
-            .hasAction("COMPLETE")
-            .hasData(mErrorAuthRedirect)
-            .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+                .hasAction("COMPLETE")
+                .hasData(mErrorAuthRedirect)
+                .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
         assertThat(mActivity).isFinishing();
     }
 
@@ -283,8 +283,8 @@ public class AuthorizationManagementActivityTest {
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            mErrorAuthRedirect));
+                RuntimeEnvironment.application,
+                mErrorAuthRedirect));
 
         // the management activity is then resumed
         mController.resume();
@@ -301,23 +301,23 @@ public class AuthorizationManagementActivityTest {
         emulateFlowToAuthorizationActivityLaunch(mStartIntentWithPendings);
 
         Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-            .build();
+                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+                .build();
 
         Intent nextStartedActivity = emulateAuthorizationResponseReceived(
-            AuthorizationManagementActivity.createResponseHandlingIntent(
-                RuntimeEnvironment.application,
-                authResponseUri));
+                AuthorizationManagementActivity.createResponseHandlingIntent(
+                        RuntimeEnvironment.application,
+                        authResponseUri));
 
         // the next activity should be from the completion intent, carrying an error
         assertThat(nextStartedActivity)
-            .hasAction("COMPLETE")
-            .hasData(authResponseUri)
-            .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+                .hasAction("COMPLETE")
+                .hasData(authResponseUri)
+                .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
 
         assertThat(AuthorizationException.fromIntent(nextStartedActivity))
-            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+                .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
     }
 
     @Test
@@ -325,14 +325,14 @@ public class AuthorizationManagementActivityTest {
         emulateFlowToAuthorizationActivityLaunch(mStartForResultIntent);
 
         Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-            .build();
+                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+                .build();
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            authResponseUri));
+                RuntimeEnvironment.application,
+                authResponseUri));
 
         // the management activity is then resumed
         mController.resume();
@@ -342,70 +342,70 @@ public class AuthorizationManagementActivityTest {
         Intent resultIntent = mActivityShadow.getResultIntent();
 
         assertThat(resultIntent)
-            .hasData(authResponseUri)
-            .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+                .hasData(authResponseUri)
+                .hasExtra(AuthorizationException.EXTRA_EXCEPTION);
 
         assertThat(AuthorizationException.fromIntent(resultIntent))
-            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+                .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
     }
 
     @Test
     public void testMismatchedState_withPendingIntentsAndNoStateInRequestWithStateInResponse() {
         AuthorizationRequest request = new AuthorizationRequest.Builder(
-            TestValues.getTestServiceConfig(),
-            TestValues.TEST_CLIENT_ID,
-            ResponseTypeValues.CODE,
-            TestValues.TEST_APP_REDIRECT_URI)
-            .setState(null)
-            .build();
+                TestValues.getTestServiceConfig(),
+                TestValues.TEST_CLIENT_ID,
+                ResponseTypeValues.CODE,
+                TestValues.TEST_APP_REDIRECT_URI)
+                .setState(null)
+                .build();
 
         Intent startIntent = createStartIntentWithPendingIntents(request, mCancelPendingIntent);
         emulateFlowToAuthorizationActivityLaunch(startIntent);
 
         Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-            .build();
+                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+                .build();
 
         // the next activity should be from the completion intent, carrying an error
         Intent nextStartedActivity = emulateAuthorizationResponseReceived(
-            AuthorizationManagementActivity.createResponseHandlingIntent(
-                RuntimeEnvironment.application,
-                authResponseUri));
+                AuthorizationManagementActivity.createResponseHandlingIntent(
+                        RuntimeEnvironment.application,
+                        authResponseUri));
 
         assertThat(AuthorizationException.fromIntent(nextStartedActivity))
-            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+                .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
     }
 
     @Test
     public void testMismatchedState_withoutPendingIntentsAndNoStateInRequestWithStateInResponse() {
         AuthorizationRequest request = new AuthorizationRequest.Builder(
-            TestValues.getTestServiceConfig(),
-            TestValues.TEST_CLIENT_ID,
-            ResponseTypeValues.CODE,
-            TestValues.TEST_APP_REDIRECT_URI)
-            .setState(null)
-            .build();
+                TestValues.getTestServiceConfig(),
+                TestValues.TEST_CLIENT_ID,
+                ResponseTypeValues.CODE,
+                TestValues.TEST_APP_REDIRECT_URI)
+                .setState(null)
+                .build();
 
         Intent startIntent = createStartForResultIntent(request);
         emulateFlowToAuthorizationActivityLaunch(startIntent);
 
         Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-            .build();
+                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+                .build();
 
         // the authorization redirect will be forwarded via a new intent
         mController.newIntent(AuthorizationManagementActivity.createResponseHandlingIntent(
-            RuntimeEnvironment.application,
-            authResponseUri));
+                RuntimeEnvironment.application,
+                authResponseUri));
 
         // the management activity is then resumed
         mController.resume();
 
         Intent resultIntent = mActivityShadow.getResultIntent();
         assertThat(AuthorizationException.fromIntent(resultIntent))
-            .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
+                .isEqualTo(AuthorizationRequestErrors.STATE_MISMATCH);
     }
 
     @Test
@@ -413,9 +413,9 @@ public class AuthorizationManagementActivityTest {
         emulateFlowToAuthorizationActivityLaunch(mStartIntentWithPendings);
 
         Uri authResponseUri = mAuthRequest.redirectUri.buildUpon()
-            .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
-            .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
-            .build();
+                .appendQueryParameter(AuthorizationResponse.KEY_STATE, "differentState")
+                .appendQueryParameter(AuthorizationResponse.KEY_AUTHORIZATION_CODE, "12345")
+                .build();
     }
 
     @Test

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -15,7 +15,6 @@
 package net.openid.appauth;
 
 import android.app.PendingIntent;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
@@ -26,7 +25,6 @@ import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.customtabs.CustomTabsServiceConnection;
 
-import android.test.mock.MockContext;
 import net.openid.appauth.AppAuthConfiguration.Builder;
 import net.openid.appauth.AuthorizationException.GeneralErrors;
 import net.openid.appauth.browser.Browsers;
@@ -42,7 +40,6 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.ByteArrayInputStream;
@@ -55,7 +52,6 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import static android.support.customtabs.CustomTabsIntent.EXTRA_ENABLE_INSTANT_APPS;
 import static android.support.customtabs.CustomTabsIntent.EXTRA_TOOLBAR_COLOR;
 import static net.openid.appauth.AuthorizationManagementActivity.KEY_AUTH_INTENT;
 import static net.openid.appauth.AuthorizationManagementActivity.KEY_AUTH_REQUEST;
@@ -135,12 +131,11 @@ public class AuthorizationServiceTest {
         MockitoAnnotations.initMocks(this);
         mAuthCallback = new AuthorizationCallback();
         mRegistrationCallback = new RegistrationCallback();
-        AppAuthConfiguration appAuthConfiguration = new Builder()
-                .setConnectionBuilder(mConnectionBuilder)
-                .build();
         mService = new AuthorizationService(
                 mContext,
-                appAuthConfiguration,
+                new Builder()
+                        .setConnectionBuilder(mConnectionBuilder)
+                        .build(),
                 Browsers.Chrome.customTab("46"),
                 mCustomTabManager);
         mOutputStream = new ByteArrayOutputStream();

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -93,28 +93,28 @@ public class AuthorizationServiceTest {
     private static final String TEST_BROWSER_PACKAGE = "com.browser.test";
 
     private static final String AUTH_CODE_EXCHANGE_RESPONSE_JSON = "{\n"
-        + "  \"refresh_token\": \"" + TEST_REFRESH_TOKEN + "\",\n"
-        + "  \"access_token\": \"" + TEST_ACCESS_TOKEN + "\",\n"
-        + "  \"expires_in\": \"" + TEST_EXPIRES_IN + "\",\n"
-        + "  \"id_token\": \"" + TEST_ID_TOKEN + "\",\n"
-        + "  \"token_type\": \"" + AuthorizationResponse.TOKEN_TYPE_BEARER + "\"\n"
-        + "}";
+            + "  \"refresh_token\": \"" + TEST_REFRESH_TOKEN + "\",\n"
+            + "  \"access_token\": \"" + TEST_ACCESS_TOKEN + "\",\n"
+            + "  \"expires_in\": \"" + TEST_EXPIRES_IN + "\",\n"
+            + "  \"id_token\": \"" + TEST_ID_TOKEN + "\",\n"
+            + "  \"token_type\": \"" + AuthorizationResponse.TOKEN_TYPE_BEARER + "\"\n"
+            + "}";
 
     private static final String REGISTRATION_RESPONSE_JSON = "{\n"
-        + " \"client_id\": \"" + TEST_CLIENT_ID + "\",\n"
-        + " \"client_secret\": \"" + TEST_CLIENT_SECRET + "\",\n"
-        + " \"client_secret_expires_at\": \"" + TEST_CLIENT_SECRET_EXPIRES_AT + "\",\n"
-        + " \"application_type\": " + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\n"
-        + "}";
+            + " \"client_id\": \"" + TEST_CLIENT_ID + "\",\n"
+            + " \"client_secret\": \"" + TEST_CLIENT_SECRET + "\",\n"
+            + " \"client_secret_expires_at\": \"" + TEST_CLIENT_SECRET_EXPIRES_AT + "\",\n"
+            + " \"application_type\": " + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\n"
+            + "}";
 
     private static final String INVALID_GRANT_RESPONSE_JSON = "{\n"
-        + "  \"error\": \"invalid_grant\",\n"
-        + "  \"error_description\": \"invalid_grant description\"\n"
-        + "}";
+            + "  \"error\": \"invalid_grant\",\n"
+            + "  \"error_description\": \"invalid_grant description\"\n"
+            + "}";
 
     private static final String INVALID_GRANT_NO_DESC_RESPONSE_JSON = "{\n"
-        + "  \"error\": \"invalid_grant\"\n"
-        + "}";
+            + "  \"error\": \"invalid_grant\"\n"
+            + "}";
 
     private static final int TEST_INVALID_GRANT_CODE = 2002;
 
@@ -136,27 +136,27 @@ public class AuthorizationServiceTest {
         mAuthCallback = new AuthorizationCallback();
         mRegistrationCallback = new RegistrationCallback();
         AppAuthConfiguration appAuthConfiguration = new Builder()
-            .setConnectionBuilder(mConnectionBuilder)
-            .build();
+                .setConnectionBuilder(mConnectionBuilder)
+                .build();
         mService = new AuthorizationService(
-            mContext,
-            appAuthConfiguration,
-            Browsers.Chrome.customTab("46"),
-            mCustomTabManager);
+                mContext,
+                appAuthConfiguration,
+                Browsers.Chrome.customTab("46"),
+                mCustomTabManager);
         mOutputStream = new ByteArrayOutputStream();
         when(mConnectionBuilder.openConnection(any(Uri.class))).thenReturn(mHttpConnection);
         when(mHttpConnection.getOutputStream()).thenReturn(mOutputStream);
         when(mContext.bindService(serviceIntentEq(), any(CustomTabsServiceConnection.class),
-            anyInt())).thenReturn(true);
+                anyInt())).thenReturn(true);
         when(mCustomTabManager.createTabBuilder())
-            .thenReturn(new CustomTabsIntent.Builder());
+                .thenReturn(new CustomTabsIntent.Builder());
     }
 
     @Test
     public void testAuthorizationRequest_withSpecifiedState() throws Exception {
         AuthorizationRequest request = getTestAuthRequestBuilder()
-            .setState(TEST_STATE)
-            .build();
+                .setState(TEST_STATE)
+                .build();
         mService.performAuthorizationRequest(request, mPendingIntent);
         Intent intent = captureAuthRequestIntent();
         assertRequestIntent(intent, null);
@@ -174,12 +174,12 @@ public class AuthorizationServiceTest {
     @Test
     public void testAuthorizationRequest_customization() throws Exception {
         CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
-            .setToolbarColor(Color.GREEN)
-            .build();
+                .setToolbarColor(Color.GREEN)
+                .build();
         mService.performAuthorizationRequest(
-            getTestAuthRequestBuilder().build(),
-            mPendingIntent,
-            customTabsIntent);
+                getTestAuthRequestBuilder().build(),
+                mPendingIntent,
+                customTabsIntent);
         Intent intent = captureAuthRequestIntent();
         assertColorMatch(intent, Color.GREEN);
     }
@@ -196,7 +196,7 @@ public class AuthorizationServiceTest {
         Intent intent = mService.getAuthorizationRequestIntent(request);
         assertThat(intent.hasExtra(KEY_AUTH_INTENT)).isTrue();
         assertThat(intent.getStringExtra(KEY_AUTH_REQUEST))
-            .isEqualTo(request.jsonSerializeString());
+                .isEqualTo(request.jsonSerializeString());
     }
 
     @Test
@@ -213,8 +213,8 @@ public class AuthorizationServiceTest {
         AuthorizationRequest request = getTestAuthRequestBuilder().build();
         @ColorInt int toolbarColor = Color.GREEN;
         CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
-            .setToolbarColor(toolbarColor)
-            .build();
+                .setToolbarColor(toolbarColor)
+                .build();
 
         Intent intent = mService.getAuthorizationRequestIntent(request, customTabsIntent);
         Intent actualAuthIntent = intent.getParcelableExtra(KEY_AUTH_INTENT);
@@ -273,7 +273,7 @@ public class AuthorizationServiceTest {
 
         // emulate some content types having already been set as an Accept value
         when(mHttpConnection.getRequestProperty("Accept"))
-            .thenReturn("text/plain");
+                .thenReturn("text/plain");
 
         when(mHttpConnection.getInputStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
@@ -297,7 +297,7 @@ public class AuthorizationServiceTest {
         String postBody = mOutputStream.toString();
         assertTokenRequestBody(postBody, request.getRequestParameters());
         verify(mHttpConnection).setRequestProperty("Authorization",
-            csb.getRequestHeaders(TEST_CLIENT_ID).get("Authorization"));
+                csb.getRequestHeaders(TEST_CLIENT_ID).get("Authorization"));
     }
 
     @Test
@@ -404,8 +404,8 @@ public class AuthorizationServiceTest {
 
         // the real auth intent is wrapped in the intent by AuthorizationManagementActivity
         return intentCaptor
-            .getValue()
-            .getParcelableExtra(KEY_AUTH_INTENT);
+                .getValue()
+                .getParcelableExtra(KEY_AUTH_INTENT);
     }
 
     private void assertTokenResponse(TokenResponse response, TokenRequest expectedRequest) {
@@ -434,7 +434,7 @@ public class AuthorizationServiceTest {
     }
 
     private void assertRegistrationResponse(RegistrationResponse response,
-        RegistrationRequest expectedRequest) {
+                                            RegistrationRequest expectedRequest) {
         assertThat(response).isNotNull();
         assertThat(response.request).isEqualTo(expectedRequest);
         assertThat(response.clientId).isEqualTo(TEST_CLIENT_ID);
@@ -443,7 +443,7 @@ public class AuthorizationServiceTest {
     }
 
     private void assertTokenRequestBody(
-        String requestBody, Map<String, String> expectedParameters) {
+            String requestBody, Map<String, String> expectedParameters) {
         Uri postBody = new Uri.Builder().encodedQuery(requestBody).build();
         for (Map.Entry<String, String> param : expectedParameters.entrySet()) {
             assertThat(postBody.getQueryParameter(param.getKey())).isEqualTo(param.getValue());
@@ -451,15 +451,15 @@ public class AuthorizationServiceTest {
     }
 
     private static class AuthorizationCallback implements
-        AuthorizationService.TokenResponseCallback {
+            AuthorizationService.TokenResponseCallback {
         private Semaphore mSemaphore = new Semaphore(0);
         public TokenResponse response;
         public AuthorizationException error;
 
         @Override
         public void onTokenRequestCompleted(
-            @Nullable TokenResponse tokenResponse,
-            @Nullable AuthorizationException ex) {
+                @Nullable TokenResponse tokenResponse,
+                @Nullable AuthorizationException ex) {
             assertTrue((tokenResponse == null) ^ (ex == null));
             this.response = tokenResponse;
             this.error = ex;
@@ -468,20 +468,20 @@ public class AuthorizationServiceTest {
 
         public void waitForCallback() throws Exception {
             assertTrue(mSemaphore.tryAcquire(CALLBACK_TIMEOUT_MILLIS,
-                TimeUnit.MILLISECONDS));
+                    TimeUnit.MILLISECONDS));
         }
     }
 
     private static class RegistrationCallback implements
-        AuthorizationService.RegistrationResponseCallback {
+            AuthorizationService.RegistrationResponseCallback {
         private Semaphore mSemaphore = new Semaphore(0);
         public RegistrationResponse response;
         public AuthorizationException error;
 
         @Override
         public void onRegistrationRequestCompleted(
-            @Nullable RegistrationResponse registrationResponse,
-            @Nullable AuthorizationException ex) {
+                @Nullable RegistrationResponse registrationResponse,
+                @Nullable AuthorizationException ex) {
             assertTrue((registrationResponse == null) ^ (ex == null));
             this.response = registrationResponse;
             this.error = ex;
@@ -490,7 +490,7 @@ public class AuthorizationServiceTest {
 
         public void waitForCallback() throws Exception {
             assertTrue(mSemaphore.tryAcquire(CALLBACK_TIMEOUT_MILLIS,
-                TimeUnit.MILLISECONDS));
+                    TimeUnit.MILLISECONDS));
         }
     }
 


### PR DESCRIPTION
As a simpler way to use AppAuth, offers a way to retrieve an intent
for use with startActivityForResult, where the authorization result 
is returned to the calling activity via onActivityResult().