### PR TITLE
Return exception on cancelation, update README

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -277,14 +277,18 @@ public class AuthorizationManagementActivity extends Activity {
 
     private void handleAuthorizationCanceled() {
         Logger.debug("Authorization flow canceled by user");
+        Intent cancelData = AuthorizationException.fromTemplate(
+                AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW,
+                null)
+                .toIntent();
         if (mCancelIntent != null) {
             try {
-                mCancelIntent.send();
+                mCancelIntent.send(this, 0, cancelData);
             } catch (CanceledException ex) {
                 Logger.error("Failed to send cancel intent", ex);
             }
         } else {
-            setResult(RESULT_CANCELED);
+            setResult(RESULT_CANCELED, cancelData);
             Logger.debug("No cancel intent set - will return to previous activity");
         }
     }

--- a/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationManagementActivityTest.java
@@ -455,6 +455,13 @@ public class AuthorizationManagementActivityTest {
 
         // at which point the cancel intent should be fired
         assertThat(mActivityShadow.getResultCode()).isEqualTo(RESULT_CANCELED);
+
+        Intent resultIntent = mActivityShadow.getResultIntent();
+        assertThat(resultIntent).hasExtra(AuthorizationException.EXTRA_EXCEPTION);
+
+        assertThat(AuthorizationException.fromIntent(resultIntent))
+            .isEqualTo(AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW);
+
         assertThat(mActivity).isFinishing();
     }
 


### PR DESCRIPTION
To ensure consistency across completion and cancelation flows, an AuthorizationException will be encoded into the cancelation response (via pending intent or activity result) to ensure a response or exception is always available.

The main README is also updated to cover the new way to trigger the authorization flow, using an Intent.