### PR TITLE
Configurable user info endpoint location

### DIFF
--- a/app/java/net/openid/appauthdemo/Configuration.java
+++ b/app/java/net/openid/appauthdemo/Configuration.java
@@ -66,6 +66,7 @@ public final class Configuration {
     private Uri mAuthEndpointUri;
     private Uri mTokenEndpointUri;
     private Uri mRegistrationEndpointUri;
+    private Uri mUserInfoEndpointUri;
     private boolean mHttpsRequired;
 
     public static Configuration getInstance(Context context) {
@@ -156,6 +157,11 @@ public final class Configuration {
         return mRegistrationEndpointUri;
     }
 
+    @Nullable
+    public Uri getUserInfoEndpointUri() {
+        return mUserInfoEndpointUri;
+    }
+
     public boolean isHttpsRequired() {
         return mHttpsRequired;
     }
@@ -203,6 +209,7 @@ public final class Configuration {
             mAuthEndpointUri = getRequiredConfigWebUri("authorization_endpoint_uri");
 
             mTokenEndpointUri = getRequiredConfigWebUri("token_endpoint_uri");
+            mUserInfoEndpointUri = getRequiredConfigWebUri("user_info_endpoint_uri");
 
             if (mClientId == null) {
                 mRegistrationEndpointUri = getRequiredConfigWebUri("registration_endpoint_uri");

--- a/app/java/net/openid/appauthdemo/TokenActivity.java
+++ b/app/java/net/openid/appauthdemo/TokenActivity.java
@@ -71,7 +71,7 @@ public class TokenActivity extends AppCompatActivity {
     private final AtomicReference<JSONObject> mUserInfoJson = new AtomicReference<>();
     private ExecutorService mExecutor;
     private Configuration mConfiguration;
-    
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/java/net/openid/appauthdemo/TokenActivity.java
+++ b/app/java/net/openid/appauthdemo/TokenActivity.java
@@ -70,13 +70,15 @@ public class TokenActivity extends AppCompatActivity {
     private AuthStateManager mStateManager;
     private final AtomicReference<JSONObject> mUserInfoJson = new AtomicReference<>();
     private ExecutorService mExecutor;
-
+    private Configuration mConfiguration;
+    
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         mStateManager = AuthStateManager.getInstance(this);
         mExecutor = Executors.newSingleThreadExecutor();
+        mConfiguration = Configuration.getInstance(this);
 
         Configuration config = Configuration.getInstance(this);
         if (config.hasConfigurationChanged()) {
@@ -221,7 +223,8 @@ public class TokenActivity extends AppCompatActivity {
 
         AuthorizationServiceDiscovery discoveryDoc =
                 state.getAuthorizationServiceConfiguration().discoveryDoc;
-        if (discoveryDoc == null || discoveryDoc.getUserinfoEndpoint() == null) {
+        if ((discoveryDoc == null || discoveryDoc.getUserinfoEndpoint() == null)
+                && mConfiguration.getUserInfoEndpointUri() == null) {
             viewProfileButton.setVisibility(View.GONE);
         } else {
             viewProfileButton.setVisibility(View.VISIBLE);
@@ -346,7 +349,10 @@ public class TokenActivity extends AppCompatActivity {
 
         URL userInfoEndpoint;
         try {
-            userInfoEndpoint = new URL(discovery.getUserinfoEndpoint().toString());
+            userInfoEndpoint =
+                    mConfiguration.getUserInfoEndpointUri() != null
+                        ? new URL(mConfiguration.getUserInfoEndpointUri().toString())
+                        : new URL(discovery.getUserinfoEndpoint().toString());
         } catch (MalformedURLException urlEx) {
             Log.e(TAG, "Failed to construct user info endpoint URL", urlEx);
             mUserInfoJson.set(null);

--- a/app/res/raw/auth_config.json
+++ b/app/res/raw/auth_config.json
@@ -6,5 +6,6 @@
   "authorization_endpoint_uri": "",
   "token_endpoint_uri": "",
   "registration_endpoint_uri": "",
+  "user_info_endpoint_uri": "",
   "https_required": true
 }


### PR DESCRIPTION
As a fix to the issue "User info endpoint configuration is only possible through the discovery url" at  https://github.com/openid/AppAuth-Android/issues/270 I have created this fix. With this fix it is possible to manually configure a user info endpoint if the auto configuration is not an option.