### PR TITLE
Synchronizes multiple actions when requiring token refresh

### DIFF
--- a/library/javatests/net/openid/appauth/AuthStateTest.java
+++ b/library/javatests/net/openid/appauth/AuthStateTest.java
@@ -505,6 +505,83 @@ public class AuthStateTest {
     }
 
     @Test
+    public void testPerformActionWithFreshToken_afterTokenExpiration_multipleActions() {
+        AuthorizationRequest authReq = getMinimalAuthRequestBuilder("id_token token code")
+            .setScope("my_scope")
+            .build();
+
+        AuthorizationResponse authResp = new AuthorizationResponse.Builder(authReq)
+            .setAccessToken(TEST_ACCESS_TOKEN)
+            .setAccessTokenExpirationTime(TWO_MINUTES)
+            .setIdToken(TEST_ID_TOKEN)
+            .setAuthorizationCode(TEST_AUTH_CODE)
+            .setState(authReq.state)
+            .build();
+        TokenResponse tokenResp = getTestAuthCodeExchangeResponse();
+        AuthState state = new AuthState(authResp, tokenResp, null);
+
+        AuthorizationService service = mock(AuthorizationService.class);
+        AuthState.AuthStateAction action = mock(AuthState.AuthStateAction.class);
+
+        // at this point in time, the access token will be considered to be expired
+        mClock.currentTime.set(TWO_MINUTES - AuthState.EXPIRY_TIME_TOLERANCE_MS + ONE_SECOND);
+        state.performActionWithFreshTokens(
+            service,
+            NoClientAuthentication.INSTANCE,
+            Collections.<String, String>emptyMap(),
+            mClock,
+            action);
+        state.performActionWithFreshTokens(
+            service,
+            NoClientAuthentication.INSTANCE,
+            Collections.<String, String>emptyMap(),
+            mClock,
+            action);
+
+        // as the access token has expired, we expect a token refresh request
+        ArgumentCaptor<TokenRequest> requestCaptor = ArgumentCaptor.forClass(TokenRequest.class);
+        ArgumentCaptor<AuthorizationService.TokenResponseCallback> callbackCaptor =
+            ArgumentCaptor.forClass(AuthorizationService.TokenResponseCallback.class);
+
+        verify(service, times(1)).performTokenRequest(
+            requestCaptor.capture(),
+            any(ClientAuthentication.class),
+            callbackCaptor.capture());
+
+        assertThat(requestCaptor.getValue().refreshToken).isEqualTo(tokenResp.refreshToken);
+
+        // the action should not be executed until after the token refresh completes
+        verifyZeroInteractions(action);
+
+        String freshRefreshToken = "fresh_refresh_token";
+        String freshAccessToken = "fresh_access_token";
+        String freshIdToken = "fresh.id.token";
+        Long freshExpirationTime = mClock.currentTime.get() + TWO_MINUTES;
+
+        // simulate success on the token request, with fresh tokens in the result
+        TokenResponse freshResponse = new TokenResponse.Builder(requestCaptor.getValue())
+            .setTokenType(TokenResponse.TOKEN_TYPE_BEARER)
+            .setAccessToken(freshAccessToken)
+            .setAccessTokenExpirationTime(freshExpirationTime)
+            .setIdToken(freshIdToken)
+            .setRefreshToken(freshRefreshToken)
+            .build();
+
+        callbackCaptor.getValue().onTokenRequestCompleted(freshResponse, null);
+        // the action should be invoked in response to the token request completion
+        verify(action, times(2)).execute(
+            eq(freshAccessToken),
+            eq(freshIdToken),
+            isNull(AuthorizationException.class));
+
+        // additionally, the auth state should be updated with the new token values
+        assertThat(state.getRefreshToken()).isEqualTo(freshRefreshToken);
+        assertThat(state.getAccessToken()).isEqualTo(freshAccessToken);
+        assertThat(state.getAccessTokenExpirationTime()).isEqualTo(freshExpirationTime);
+        assertThat(state.getIdToken()).isEqualTo(freshIdToken);
+    }
+
+    @Test
     public void testJsonSerialization() throws Exception {
         AuthorizationRequest authReq = getMinimalAuthRequestBuilder("id_token token code")
                 .setScopes(


### PR DESCRIPTION
This fixes issue #309 by maintaining a collection of pending actions when multiple performActionWithFreshTokens calls have been made but the access token has expired. Issue #309 occurs when the second request hits the authorization server, the refresh token contained in the TokenRequest does not match the refresh token on the auth server. Now instead of making multiple TokenRequests, it appends the action to a list of pending actions, and when the first TokenRequest returns from auth server, it executes all of the pending actions using the one TokenResponse for all of them. 