### PR TITLE
Make handling of non-standard expires_at more tolerant

### DIFF
--- a/library/java/net/openid/appauth/JsonUtil.java
+++ b/library/java/net/openid/appauth/JsonUtil.java
@@ -249,11 +249,15 @@ final class JsonUtil {
             throws JSONException {
         checkNotNull(json, "json must not be null");
         checkNotNull(field, "field must not be null");
-        if (!json.has(field)) {
+        if (!json.has(field) || json.isNull(field)) {
             return null;
         }
 
-        return json.getLong(field);
+        try {
+            return json.getLong(field);
+        } catch (JSONException e) {
+            return null;
+        }
     }
 
     @NonNull

--- a/library/java/net/openid/appauth/TokenResponse.java
+++ b/library/java/net/openid/appauth/TokenResponse.java
@@ -215,9 +215,7 @@ public class TokenResponse {
         public Builder fromResponseJson(@NonNull JSONObject json) throws JSONException {
             setTokenType(JsonUtil.getString(json, KEY_TOKEN_TYPE));
             setAccessToken(JsonUtil.getStringIfDefined(json, KEY_ACCESS_TOKEN));
-            if (json.has(KEY_EXPIRES_AT)) {
-                setAccessTokenExpirationTime(json.getLong(KEY_EXPIRES_AT));
-            }
+            setAccessTokenExpirationTime(JsonUtil.getLongIfDefined(json, KEY_EXPIRES_AT));
             if (json.has(KEY_EXPIRES_IN)) {
                 setAccessTokenExpiresIn(json.getLong(KEY_EXPIRES_IN));
             }


### PR DESCRIPTION
This commit stops token responses from failing to parse when an `expires_at` field is not a long. This is true for Sentry.io's OAuth2 implementation, which responds with an ISO date string for that field, and as this field is not defined in the OAuth 2 RFC, there is no reason for this field to be strictly handled.