### PR TITLE
Fix manifest placeholder processing

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,11 +9,18 @@ version = rootProject.versionName
 
 android.defaultConfig.project.archivesBaseName = 'appauth'
 
-// Define a default value for building the tests. This is not used when building any dependent
-// libraries or apps.
-android.buildTypes.debug.manifestPlaceholders = [
-    'appAuthRedirectScheme': 'net.openid.appauth.test'
-];
+// use a separate build type for unit tests, so that we can configure the manifest placeholder
+// without interfering with other builds.
+android.buildTypes {
+    forTests {
+        initWith debug
+        manifestPlaceholders = [
+            'appAuthRedirectScheme': 'net.openid.appauth.test'
+        ]
+    }
+}
+
+android.testBuildType "forTests"
 
 dependencies {
     api "com.android.support:customtabs:${rootProject.supportLibVersion}"


### PR DESCRIPTION
Apparently manifest placeholder processing has changed in recent android gradle plugin versions, such that the test value specified for the library is now taking precedence over values specified for the demo app project. This change fixes the issue by creating a new build type that the unit tests use, where the manifest placeholder can be independently changed.