### PR TITLE
Fix encoding of client ids and secrets for auth

### DIFF
--- a/library/java/net/openid/appauth/ClientSecretBasic.java
+++ b/library/java/net/openid/appauth/ClientSecretBasic.java
@@ -21,7 +21,6 @@ import android.util.Base64;
 
 import net.openid.appauth.internal.UriUtil;
 
-import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.Map;
 

--- a/library/java/net/openid/appauth/ClientSecretBasic.java
+++ b/library/java/net/openid/appauth/ClientSecretBasic.java
@@ -19,6 +19,9 @@ import static net.openid.appauth.Preconditions.checkNotNull;
 import android.support.annotation.NonNull;
 import android.util.Base64;
 
+import net.openid.appauth.internal.UriUtil;
+
+import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.Map;
 
@@ -50,7 +53,11 @@ public class ClientSecretBasic implements ClientAuthentication {
 
     @Override
     public final Map<String, String> getRequestHeaders(@NonNull String clientId) {
-        String credentials = clientId + ":" + mClientSecret;
+        // From the OAuth2 RFC, client ID and secret should be encoded prior to concatenation and
+        // conversion to Base64: https://tools.ietf.org/html/rfc6749#section-2.3.1
+        String encodedClientId = UriUtil.formUrlEncodeValue(clientId);
+        String encodedClientSecret = UriUtil.formUrlEncodeValue(mClientSecret);
+        String credentials = encodedClientId + ":" + encodedClientSecret;
         String basicAuth = Base64.encodeToString(credentials.getBytes(), Base64.NO_WRAP);
         return Collections.singletonMap("Authorization", "Basic " + basicAuth);
     }

--- a/library/java/net/openid/appauth/internal/UriUtil.java
+++ b/library/java/net/openid/appauth/internal/UriUtil.java
@@ -95,21 +95,28 @@ public final class UriUtil {
         return uriBundles;
     }
 
-    public static String formUrlEncode(Map<String, String> parameters) {
+    @NonNull
+    public static String formUrlEncode(@Nullable Map<String, String> parameters) {
         if (parameters == null) {
             return "";
         }
 
         List<String> queryParts = new ArrayList<>();
         for (Map.Entry<String, String> param : parameters.entrySet()) {
-            try {
-                queryParts.add(param.getKey() + "=" + URLEncoder.encode(param.getValue(), "utf-8"));
-            } catch (UnsupportedEncodingException e) {
-                // Should not end up here
-                Logger.error("Could not utf-8 encode.");
-            }
+            queryParts.add(param.getKey() + "=" + formUrlEncodeValue(param.getValue()));
         }
         return TextUtils.join("&", queryParts);
+    }
+
+    @NonNull
+    public static String formUrlEncodeValue(@NonNull String value) {
+        Preconditions.checkNotNull(value);
+        try {
+            return URLEncoder.encode(value, "utf-8");
+        } catch (UnsupportedEncodingException ex) {
+            // utf-8 should always be supported
+            throw new IllegalStateException("Unable to encode using UTF-8");
+        }
     }
 
     public static List<Pair<String, String>> formUrlDecode(String encoded) {

--- a/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
+++ b/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
@@ -42,17 +42,42 @@ public class ClientSecretBasicTest {
     }
 
     @Test
-    public void getGetRequestHeaders_idAndSecretAreUrlEncoded() {
+    public void testGetRequestHeaders_idAndSecretAreUrlEncoded() {
         String secretThatChangesWhenEncoded = "1/2_3+4";
         String idThatChangesWhenEncoded = "0!1*$$";
         ClientSecretBasic csb = new ClientSecretBasic(secretThatChangesWhenEncoded);
 
-
-        csb.getRequestHeaders(idThatChangesWhenEncoded);
         String expectedAuthzHeader = "Basic MCUyMTEqJTI0JTI0OjElMkYyXzMlMkI0";
 
         Map<String, String> headers = csb.getRequestHeaders(idThatChangesWhenEncoded);
-        assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers).containsEntry("Authorization", expectedAuthzHeader);
+    }
+
+    @Test
+    public void testGetRequestHeaders_testValuesFromIssue337() {
+        // see: https://github.com/openid/AppAuth-Android/issues/337
+
+        String secret = "z/tZ9VwFZqApmIQ+ZH1I5pLk/uB4ud:X2/8bL+wfFTt1rFw=";
+        String id = "1PpG/Q 1";
+        ClientSecretBasic csb = new ClientSecretBasic(secret);
+
+        String expectedAuthzHeader = "Basic " +
+            "MVBwRyUyRlErMTp6JTJGdFo5VndGWnFBcG1JUSUyQlpIMUk1cExrJTJGdUI0dWQl" +
+            "M0FYMiUyRjhiTCUyQndmRlR0MXJGdyUzRA==";
+
+        assertThat(csb.getRequestHeaders(id)).containsEntry("Authorization", expectedAuthzHeader);
+    }
+
+    @Test
+    public void testGetRequestHeaders_idAndSecretWithAllReservedCharacters() {
+        String secretWithSpaces = "i am a secret";
+        String idWithSpaces = "i am an ID";
+
+        ClientSecretBasic csb = new ClientSecretBasic(secretWithSpaces);
+
+        String expectedAuthzHeader = "Basic ";
+
+        Map<String, String> headers = csb.getRequestHeaders(idWithSpaces);
         assertThat(headers).containsEntry("Authorization", expectedAuthzHeader);
     }
 

--- a/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
+++ b/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
@@ -31,12 +31,9 @@ public class ClientSecretBasicTest {
     @Test
     public void testGetRequestHeaders() {
         ClientSecretBasic csb = new ClientSecretBasic(TEST_CLIENT_SECRET);
-
         Map<String, String> headers = csb.getRequestHeaders(TEST_CLIENT_ID);
 
-        String credentials = TEST_CLIENT_ID + ":" + TEST_CLIENT_SECRET;
-        String authz = Base64.encodeToString(credentials.getBytes(), Base64.NO_WRAP);
-        String expectedAuthzHeader = "Basic " + authz;
+        String expectedAuthzHeader = "Basic dGVzdF9jbGllbnRfaWQ6dGVzdF9jbGllbnRfc2VjcmV0";
         assertThat(headers.size()).isEqualTo(1);
         assertThat(headers).containsEntry("Authorization", expectedAuthzHeader);
     }
@@ -69,15 +66,25 @@ public class ClientSecretBasicTest {
     }
 
     @Test
-    public void testGetRequestHeaders_idAndSecretWithAllReservedCharacters() {
-        String secretWithSpaces = "i am a secret";
-        String idWithSpaces = "i am an ID";
+    public void testGetRequestHeaders_encodingTests() {
+        // the set of characters that must be transformed is defined in the WHATWG URL spec here:
+        // https://url.spec.whatwg.org/#urlencoded-serializing
 
-        ClientSecretBasic csb = new ClientSecretBasic(secretWithSpaces);
+        // based on the above, let the secret be the string containing all the ascii characters that
+        // are not encoded ...
+        String secret = "*-._0123456789abcdefghijklmnoprstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-        String expectedAuthzHeader = "Basic ";
+        // ... and let the id contain a selection of characters that do require encoding
+        String id = "!@#$%^&()_=+µΩß¡";
 
-        Map<String, String> headers = csb.getRequestHeaders(idWithSpaces);
+        ClientSecretBasic csb = new ClientSecretBasic(secret);
+
+        String expectedAuthzHeader = "Basic " +
+            "JTIxJTQwJTIzJTI0JTI1JTVFJTI2JTI4JTI5XyUzRCUyQiVDMiVCNSVDRSVBOSVD" +
+            "MyU5RiVDMiVBMToqLS5fMDEyMzQ1Njc4OWFiY2RlZmdoaWprbG1ub3Byc3R1dnd4" +
+            "eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWg==";
+
+        Map<String, String> headers = csb.getRequestHeaders(id);
         assertThat(headers).containsEntry("Authorization", expectedAuthzHeader);
     }
 

--- a/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
+++ b/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
@@ -42,6 +42,21 @@ public class ClientSecretBasicTest {
     }
 
     @Test
+    public void getGetRequestHeaders_idAndSecretAreUrlEncoded() {
+        String secretThatChangesWhenEncoded = "1/2_3+4";
+        String idThatChangesWhenEncoded = "0!1*$$";
+        ClientSecretBasic csb = new ClientSecretBasic(secretThatChangesWhenEncoded);
+
+
+        csb.getRequestHeaders(idThatChangesWhenEncoded);
+        String expectedAuthzHeader = "Basic MCUyMTEqJTI0JTI0OjElMkYyXzMlMkI0";
+
+        Map<String, String> headers = csb.getRequestHeaders(idThatChangesWhenEncoded);
+        assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers).containsEntry("Authorization", expectedAuthzHeader);
+    }
+
+    @Test
     public void testGetRequestParameters() {
         ClientSecretBasic csb = new ClientSecretBasic(TEST_CLIENT_SECRET);
         assertThat(csb.getRequestParameters(TEST_CLIENT_ID)).isNull();

--- a/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
+++ b/library/javatests/net/openid/appauth/ClientSecretBasicTest.java
@@ -18,12 +18,13 @@ import static net.openid.appauth.TestValues.TEST_CLIENT_ID;
 import static net.openid.appauth.TestValues.TEST_CLIENT_SECRET;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import android.util.Base64;
 import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk=16)


### PR DESCRIPTION
Fixes the encoding of client ids and secrets when performing client
secret basic auth.