### PR TITLE
Add support for custom tabs in Firefox

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Alex Chau <alexchau@google.com>
 Benjamin Franz <bfranz@google.com>
 Rebecka Gulliksson <rebecka.gulliksson@gmail.com>
 Rahul Ravikumar <rahulrav@google.com>
+Henning Nielsen Lund <henning.n.lund@jp.dk>

--- a/library/java/net/openid/appauth/browser/BrowserBlacklist.java
+++ b/library/java/net/openid/appauth/browser/BrowserBlacklist.java
@@ -31,7 +31,8 @@ import java.util.List;
  *
  * // blacklist Firefox
  * new BrowserBlacklist(
- *     VersionedBrowserMatcher.FIREFOX_BROWSER);
+ *     VersionedBrowserMatcher.FIREFOX_BROWSER,
+ *     VersionedBrowserMatcher.FIREFOX_CUSTOM_TAB);
  *
  * // blacklist Dolphin Browser
  * new BrowserBlacklist(

--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -82,7 +82,8 @@ public final class BrowserSelector {
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
             queryFlag |= PackageManager.MATCH_ALL;
         }
-        ResolveInfo resolvedDefaultActivity = pm.resolveActivity(BROWSER_INTENT, 0);
+        ResolveInfo resolvedDefaultActivity =
+            pm.resolveActivity(BROWSER_INTENT, 0);
         if (resolvedDefaultActivity != null) {
             defaultBrowserPackage = resolvedDefaultActivity.activityInfo.packageName;
         }
@@ -102,7 +103,8 @@ public final class BrowserSelector {
                         PackageManager.GET_SIGNATURES);
 
                 if (hasWarmupService(pm, info.activityInfo.packageName)) {
-                    BrowserDescriptor customTabBrowserDescriptor = new BrowserDescriptor(packageInfo, true);
+                    BrowserDescriptor customTabBrowserDescriptor =
+                        new BrowserDescriptor(packageInfo, true);
                     if (info.activityInfo.packageName.equals(defaultBrowserPackage)) {
                         browsers.add(defaultBrowserIndex, customTabBrowserDescriptor);
                         defaultBrowserIndex++;
@@ -111,7 +113,8 @@ public final class BrowserSelector {
                     }
                 }
 
-                BrowserDescriptor fullBrowserDescriptor = new BrowserDescriptor(packageInfo, false);
+                BrowserDescriptor fullBrowserDescriptor =
+                    new BrowserDescriptor(packageInfo, false);
                 if (info.activityInfo.packageName.equals(defaultBrowserPackage)) {
                     browsers.add(defaultBrowserIndex, fullBrowserDescriptor);
                 } else {

--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -83,7 +83,7 @@ public final class BrowserSelector {
             queryFlag |= PackageManager.MATCH_ALL;
         }
         ResolveInfo resolvedDefaultActivity =
-            pm.resolveActivity(BROWSER_INTENT, 0);
+                pm.resolveActivity(BROWSER_INTENT, 0);
         if (resolvedDefaultActivity != null) {
             defaultBrowserPackage = resolvedDefaultActivity.activityInfo.packageName;
         }
@@ -104,7 +104,7 @@ public final class BrowserSelector {
 
                 if (hasWarmupService(pm, info.activityInfo.packageName)) {
                     BrowserDescriptor customTabBrowserDescriptor =
-                        new BrowserDescriptor(packageInfo, true);
+                            new BrowserDescriptor(packageInfo, true);
                     if (info.activityInfo.packageName.equals(defaultBrowserPackage)) {
                         browsers.add(defaultBrowserIndex, customTabBrowserDescriptor);
                         defaultBrowserIndex++;
@@ -114,7 +114,7 @@ public final class BrowserSelector {
                 }
 
                 BrowserDescriptor fullBrowserDescriptor =
-                    new BrowserDescriptor(packageInfo, false);
+                        new BrowserDescriptor(packageInfo, false);
                 if (info.activityInfo.packageName.equals(defaultBrowserPackage)) {
                     browsers.add(defaultBrowserIndex, fullBrowserDescriptor);
                 } else {

--- a/library/java/net/openid/appauth/browser/Browsers.java
+++ b/library/java/net/openid/appauth/browser/Browsers.java
@@ -62,7 +62,7 @@ public final class Browsers {
         }
 
         /**
-         * Creates a browser descriptor fot the specified version of Chrome, when used as
+         * Creates a browser descriptor for the specified version of Chrome, when used as
          * a custom tab.
          */
         public static BrowserDescriptor customTab(@NonNull String version) {
@@ -98,11 +98,25 @@ public final class Browsers {
                 Collections.singleton(SIGNATURE_HASH);
 
         /**
+         * The version in which Custom Tabs were introduced in Firefox.
+         */
+        public static final DelimitedVersion MINIMUM_VERSION_FOR_CUSTOM_TAB =
+                DelimitedVersion.parse("57");
+
+        /**
          * Creates a browser descriptor for the specified version of Firefox, when used
          * as a standalone browser.
          */
         public static BrowserDescriptor standaloneBrowser(@NonNull String version) {
             return new BrowserDescriptor(PACKAGE_NAME, SIGNATURE_SET, version, false);
+        }
+
+        /**
+         * Creates a browser descriptor for the specified version of Firefox, when used as
+         * a custom tab.
+         */
+        public static BrowserDescriptor customTab(@NonNull String version) {
+            return new BrowserDescriptor(PACKAGE_NAME, SIGNATURE_SET, version, true);
         }
 
         private Firefox() {

--- a/library/java/net/openid/appauth/browser/VersionedBrowserMatcher.java
+++ b/library/java/net/openid/appauth/browser/VersionedBrowserMatcher.java
@@ -44,6 +44,15 @@ public class VersionedBrowserMatcher implements BrowserMatcher {
             VersionRange.ANY_VERSION);
 
     /**
+     * Matches any version of Firefox for use as a custom tab.
+     */
+    public static final VersionedBrowserMatcher FIREFOX_CUSTOM_TAB = new VersionedBrowserMatcher(
+            Browsers.Firefox.PACKAGE_NAME,
+            Browsers.Firefox.SIGNATURE_SET,
+            true,
+            VersionRange.atLeast(Browsers.Firefox.MINIMUM_VERSION_FOR_CUSTOM_TAB));
+
+    /**
      * Matches any version of Mozilla Firefox.
      */
     public static final VersionedBrowserMatcher FIREFOX_BROWSER = new VersionedBrowserMatcher(

--- a/library/javatests/net/openid/appauth/browser/BrowserWhitelistTest.java
+++ b/library/javatests/net/openid/appauth/browser/BrowserWhitelistTest.java
@@ -31,6 +31,7 @@ public class BrowserWhitelistTest {
         BrowserWhitelist whitelist = new BrowserWhitelist();
         assertThat(whitelist.matches(Browsers.Chrome.customTab("46"))).isFalse();
         assertThat(whitelist.matches(Browsers.Firefox.standaloneBrowser("10"))).isFalse();
+        assertThat(whitelist.matches(Browsers.Firefox.customTab("57"))).isFalse();
         assertThat(whitelist.matches(Browsers.SBrowser.standaloneBrowser("11"))).isFalse();
     }
 
@@ -40,6 +41,7 @@ public class BrowserWhitelistTest {
         assertThat(whitelist.matches(Browsers.Chrome.standaloneBrowser("46"))).isTrue();
         assertThat(whitelist.matches(Browsers.Chrome.customTab("46"))).isFalse();
         assertThat(whitelist.matches(Browsers.Firefox.standaloneBrowser("10"))).isFalse();
+        assertThat(whitelist.matches(Browsers.Firefox.customTab("57"))).isFalse();
     }
 
     @Test
@@ -50,17 +52,21 @@ public class BrowserWhitelistTest {
         assertThat(whitelist.matches(Browsers.Chrome.standaloneBrowser("46"))).isTrue();
         assertThat(whitelist.matches(Browsers.Chrome.customTab("46"))).isTrue();
         assertThat(whitelist.matches(Browsers.Firefox.standaloneBrowser("10"))).isFalse();
+        assertThat(whitelist.matches(Browsers.Firefox.customTab("57"))).isFalse();
     }
 
     @Test
     public void testMatches_firefoxOrSamsung() {
         BrowserWhitelist whitelist = new BrowserWhitelist(
                 VersionedBrowserMatcher.FIREFOX_BROWSER,
+                VersionedBrowserMatcher.FIREFOX_CUSTOM_TAB,
                 VersionedBrowserMatcher.SAMSUNG_BROWSER,
                 VersionedBrowserMatcher.SAMSUNG_CUSTOM_TAB);
         assertThat(whitelist.matches(Browsers.Chrome.standaloneBrowser("46"))).isFalse();
         assertThat(whitelist.matches(Browsers.Chrome.customTab("46"))).isFalse();
         assertThat(whitelist.matches(Browsers.Firefox.standaloneBrowser("10"))).isTrue();
+        assertThat(whitelist.matches(Browsers.Firefox.customTab("56"))).isFalse();
+        assertThat(whitelist.matches(Browsers.Firefox.customTab("57"))).isTrue();
         assertThat(whitelist.matches(Browsers.SBrowser.standaloneBrowser("10"))).isTrue();
         assertThat(whitelist.matches(Browsers.SBrowser.customTab("10"))).isTrue();
     }


### PR DESCRIPTION
support for custom tabs was added to stable Firefox in version 57.0

fixes: #368
Signed-off-by: Henning Nielsen Lund <henning.n.lund@jp.dk>