### PR TITLE
Custom Tabs was first added in Samsung Internet 4.0

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Alex Chau <alexchau@google.com>
 Benjamin Franz <bfranz@google.com>
 Rebecka Gulliksson <rebecka.gulliksson@gmail.com>
 Rahul Ravikumar <rahulrav@google.com>
+Henning Nielsen Lund <henning.n.lund@jp.dk>

--- a/library/java/net/openid/appauth/browser/Browsers.java
+++ b/library/java/net/openid/appauth/browser/Browsers.java
@@ -136,6 +136,12 @@ public final class Browsers {
                 Collections.singleton(SIGNATURE_HASH);
 
         /**
+         * The version in which Custom Tabs were introduced in Samsung Internet.
+         */
+        public static final DelimitedVersion MINIMUM_VERSION_FOR_CUSTOM_TAB =
+                DelimitedVersion.parse("4.0");
+
+        /**
          * Creates a browser descriptor for the specified version of SBrowser, when
          * used as a standalone browser.
          */

--- a/library/java/net/openid/appauth/browser/VersionedBrowserMatcher.java
+++ b/library/java/net/openid/appauth/browser/VersionedBrowserMatcher.java
@@ -68,7 +68,7 @@ public class VersionedBrowserMatcher implements BrowserMatcher {
             Browsers.SBrowser.PACKAGE_NAME,
             Browsers.SBrowser.SIGNATURE_SET,
             true,
-            VersionRange.ANY_VERSION);
+            VersionRange.atLeast(Browsers.SBrowser.MINIMUM_VERSION_FOR_CUSTOM_TAB));
 
     private String mPackageName;
     private Set<String> mSignatureHashes;

--- a/library/javatests/net/openid/appauth/browser/AnyBrowserMatcherTest.java
+++ b/library/javatests/net/openid/appauth/browser/AnyBrowserMatcherTest.java
@@ -34,5 +34,7 @@ public class AnyBrowserMatcherTest {
                 .isTrue();
         assertThat(AnyBrowserMatcher.INSTANCE.matches(Browsers.SBrowser.standaloneBrowser("2.1")))
                 .isTrue();
+        assertThat(AnyBrowserMatcher.INSTANCE.matches(Browsers.SBrowser.customTab("4.0")))
+                .isTrue();
     }
 }

--- a/library/javatests/net/openid/appauth/browser/BrowserWhitelistTest.java
+++ b/library/javatests/net/openid/appauth/browser/BrowserWhitelistTest.java
@@ -62,7 +62,8 @@ public class BrowserWhitelistTest {
         assertThat(whitelist.matches(Browsers.Chrome.customTab("46"))).isFalse();
         assertThat(whitelist.matches(Browsers.Firefox.standaloneBrowser("10"))).isTrue();
         assertThat(whitelist.matches(Browsers.SBrowser.standaloneBrowser("10"))).isTrue();
-        assertThat(whitelist.matches(Browsers.SBrowser.customTab("10"))).isTrue();
+        assertThat(whitelist.matches(Browsers.SBrowser.customTab("4.0"))).isTrue();
+        assertThat(whitelist.matches(Browsers.SBrowser.customTab("3.9"))).isFalse();
     }
 
 }


### PR DESCRIPTION
At the moment all versions of the Samsung Internet Browser is set to support Custom Tabs. Support for Custom Tabs was first added in version 4.0.

fixes: #382
Signed-off-by: Henning Nielsen Lund <henning.n.lund@jp.dk>