### PR TITLE
Change launchMode to singleTop

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * Copyright 2015 The AppAuth for Android Authors. All Rights Reserved.
+ * Copyright 2018 The AppAuth for Android Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,7 +21,7 @@
     <activity android:name=".AuthorizationManagementActivity"
       android:exported="false"
       android:theme="@android:style/Theme.Translucent.NoTitleBar"
-      android:launchMode="singleTask" />
+      android:launchMode="singleTop" />
 
     <activity android:name=".RedirectUriReceiverActivity" android:exported="true">
       <intent-filter>


### PR DESCRIPTION
Changing the lauchMode to singleTop fixes the problem with Android < 5.0

Tested with customTabs and stand alone browsers and it is working. The problem that was experienced with singleInstance is not pressent with singleTop: https://github.com/openid/AppAuth-Android/issues/170#issuecomment-280952807

Fixes: https://github.com/openid/AppAuth-Android/issues/299
Signed-off-by: Henning Nielsen Lund <henning.n.lund@jp.dk>