### PR TITLE
add BrowserNotSupportedException

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -218,8 +218,8 @@ public class AuthorizationService {
      *     be created with the help of {@link #createCustomTabsIntentBuilder(Uri[])}, which will
      *     ensure that a warmed-up version of the browser will be used, minimizing latency.
      *
-     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available to
-     *     perform the authorization flow.
+     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available
+     *     to perform the authorization flow.
      */
     public void performAuthorizationRequest(
             @NonNull AuthorizationRequest request,
@@ -258,8 +258,8 @@ public class AuthorizationService {
      *     be created with the help of {@link #createCustomTabsIntentBuilder(Uri[])}, which will
      *     ensure that a warmed-up version of the browser will be used, minimizing latency.
      *
-     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available to
-     *     perform the authorization flow.
+     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available
+     *     to perform the authorization flow.
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public Intent getAuthorizationRequestIntent(
@@ -289,8 +289,8 @@ public class AuthorizationService {
      * {@link Activity#RESULT_OK} indicates the authorization request completed,
      * not necessarily that it was a successful authorization.
      *
-     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available to
-     *     perform the authorization flow.
+     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available
+     *     to perform the authorization flow.
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public Intent getAuthorizationRequestIntent(

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -15,10 +15,10 @@
 package net.openid.appauth;
 
 import static net.openid.appauth.Preconditions.checkNotNull;
+import static net.openid.appauth.browser.BrowserSelector.getAllBrowsers;
 
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URLConnection;
+import java.util.List;
 import java.util.Map;
 
 
@@ -217,7 +218,7 @@ public class AuthorizationService {
      *     be created with the help of {@link #createCustomTabsIntentBuilder(Uri[])}, which will
      *     ensure that a warmed-up version of the browser will be used, minimizing latency.
      *
-     * @throws android.content.ActivityNotFoundException if no suitable browser is available to
+     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available to
      *     perform the authorization flow.
      */
     public void performAuthorizationRequest(
@@ -257,7 +258,7 @@ public class AuthorizationService {
      *     be created with the help of {@link #createCustomTabsIntentBuilder(Uri[])}, which will
      *     ensure that a warmed-up version of the browser will be used, minimizing latency.
      *
-     * @throws android.content.ActivityNotFoundException if no suitable browser is available to
+     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available to
      *     perform the authorization flow.
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -288,7 +289,7 @@ public class AuthorizationService {
      * {@link Activity#RESULT_OK} indicates the authorization request completed,
      * not necessarily that it was a successful authorization.
      *
-     * @throws android.content.ActivityNotFoundException if no suitable browser is available to
+     * @throws net.openid.appauth.BrowserNotSupportedException if no suitable browser is available to
      *     perform the authorization flow.
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -371,7 +372,12 @@ public class AuthorizationService {
         checkNotDisposed();
 
         if (mBrowser == null) {
-            throw new ActivityNotFoundException();
+            List<BrowserDescriptor> browsers = getAllBrowsers(mContext);
+            if (browsers.isEmpty()) {
+                throw new BrowserNotSupportedException();
+            } else {
+                throw new BrowserNotSupportedException(browsers.get(0));
+            }
         }
 
         Uri requestUri = request.toUri();

--- a/library/java/net/openid/appauth/BrowserNotSupportedException.java
+++ b/library/java/net/openid/appauth/BrowserNotSupportedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openid.appauth;
+
+import net.openid.appauth.browser.BrowserDescriptor;
+
+/**
+ * Returned as a response to prepareAuthorizationRequestIntent if no supported browser is installed.
+ */
+public final class BrowserNotSupportedException extends RuntimeException {
+
+    /**
+     * No supported Browser is installed on the device.
+     */
+    public BrowserNotSupportedException() {
+        super();
+    }
+
+    /**
+     * No supported Browser is installed on the device.
+     * Include the default browser installed on the device.
+     */
+    public BrowserNotSupportedException(BrowserDescriptor defaultBrowser) {
+        super(defaultBrowser.packageName);
+    }
+}


### PR DESCRIPTION
let prepareAuthorizationRequestIntent throw a BrowserNotSupportedException if none of the browsers installed is supported. Use the packagename of the default browser as a message, if there is a browser installed.

fixes: https://github.com/openid/AppAuth-Android/issues/400
Signed-off-by: Henning Nielsen Lund <henning.n.lund@jp.dk>