### PR TITLE
Use CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION in BrowserSelector.

### DIFF
--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -27,6 +27,7 @@ import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.support.customtabs.CustomTabsService;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -52,7 +53,7 @@ public final class BrowserSelector {
      */
     @VisibleForTesting
     static final String ACTION_CUSTOM_TABS_CONNECTION =
-            "android.support.customtabs.action.CustomTabsService";
+            CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION;
 
     /**
      * An arbitrary (but unregistrable, per


### PR DESCRIPTION
* This helps with the jetification. I produced an artifact locally,
  and wrote a sample app using:

  ```gradle
  implementation 'androidx.appcompat:appcompat:1.0.0-rc02'
  implementation 'androidx.browser:browser:1.0.0-rc02'
  ```

  to make sure that the app works.

Fixes: https://github.com/openid/AppAuth-Android/issues/395