### PR TITLE
Issue #402: fixes NPE in case input stream is null

### DIFF
--- a/library/java/net/openid/appauth/Utils.java
+++ b/library/java/net/openid/appauth/Utils.java
@@ -33,6 +33,10 @@ class Utils {
      * Read a string from an input stream.
      */
     public static String readInputStream(InputStream in) throws IOException {
+        if (in == null) {
+            throw new  IOException("Input stream must not be null");
+        }
+
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
         char[] buffer = new char[INITIAL_READ_BUFFER_SIZE];
         StringBuilder sb = new StringBuilder();

--- a/library/java/net/openid/appauth/Utils.java
+++ b/library/java/net/openid/appauth/Utils.java
@@ -34,7 +34,7 @@ class Utils {
      */
     public static String readInputStream(InputStream in) throws IOException {
         if (in == null) {
-            throw new  IOException("Input stream must not be null");
+            throw new IOException("Input stream must not be null");
         }
 
         BufferedReader br = new BufferedReader(new InputStreamReader(in));

--- a/library/javatests/net/openid/appauth/UtilsTest.java
+++ b/library/javatests/net/openid/appauth/UtilsTest.java
@@ -66,4 +66,9 @@ public class UtilsTest {
         InputStream in = new ByteArrayInputStream(TEST_STRING.getBytes());
         assertEquals(TEST_STRING, Utils.readInputStream(in));
     }
+
+    @Test(expected = IOException.class)
+    public void testReadInputStream_throw() throws Exception{
+        Utils.readInputStream(null);
+    }
 }


### PR DESCRIPTION
- fixes NPE by checking for null and throwing an IOException instead