### PR TITLE
workaround androidx jetifier

### DIFF
--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -27,7 +27,6 @@ import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.support.customtabs.CustomTabsService;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -53,8 +52,9 @@ public final class BrowserSelector {
      */
     @SuppressWarnings("StringBufferReplaceableByString")
     @VisibleForTesting
-    static final String ACTION_CUSTOM_TABS_CONNECTION =
-        new StringBuilder().append("android.sup").append("port.customtabs.action.CustomTabsService").toString();
+    static final String ACTION_CUSTOM_TABS_CONNECTION = new StringBuilder()
+            .append("android.")
+            .append("support.customtabs.action.CustomTabsService").toString();
 
     /**
      * An arbitrary (but unregistrable, per

--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -49,6 +49,18 @@ public final class BrowserSelector {
 
     /**
      * The service we expect to find on a web browser that indicates it supports custom tabs.
+     *
+     * Workaround for Android Jetifier bug (https://issuetracker.google.com/issues/119183822)
+     *
+     * Problem: Projects that are using androidx are using a Jetifier compiler as a dependency.
+     * The Jetifier compiler is replacing "android.support" with "androidx" inside all the
+     * dependencies, AppAuth included. But "android.support" is still required by the platform in
+     * order to open a chrome tab. As a result - a chrome tab is not found, and an external browser
+     * is opened instead.
+     * Workaround: Using StringBuilder to create the string
+     * "android.support.customtabs.action.CustomTabsService" in runtime prevents the jetifier static
+     * regex from matching "android.support" in the compiled class, thus avoiding the androidx
+     * replacement.
      */
     @SuppressWarnings("StringBufferReplaceableByString")
     @VisibleForTesting

--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -51,9 +51,10 @@ public final class BrowserSelector {
     /**
      * The service we expect to find on a web browser that indicates it supports custom tabs.
      */
+    @SuppressWarnings("StringBufferReplaceableByString")
     @VisibleForTesting
     static final String ACTION_CUSTOM_TABS_CONNECTION =
-            CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION;
+        new StringBuilder().append("android.sup").append("port.customtabs.action.CustomTabsService").toString();
 
     /**
      * An arbitrary (but unregistrable, per


### PR DESCRIPTION
This workaround prevents androidx jetifier from replacing a hard-coded android.support string with its androidx counterpart that doesn't work.
It is backward compatible with pre-androidx projects, and makes AppAuth-Android work seamlessly with androidx projects.