### PR TITLE
Dispose opened streams and connections

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
@@ -322,9 +322,10 @@ public class AuthorizationServiceConfiguration {
 
         @Override
         protected AuthorizationServiceConfiguration doInBackground(Void... voids) {
+            HttpURLConnection conn = null;
             InputStream is = null;
             try {
-                HttpURLConnection conn = mConnectionBuilder.openConnection(mUri);
+                conn = mConnectionBuilder.openConnection(mUri);
                 conn.setRequestMethod("GET");
                 conn.setDoInput(true);
                 conn.connect();
@@ -352,6 +353,9 @@ public class AuthorizationServiceConfiguration {
                         ex);
             } finally {
                 Utils.closeQuietly(is);
+                if (conn != null) {
+                    conn.disconnect();
+                }
             }
             return null;
         }

--- a/library/java/net/openid/appauth/Utils.java
+++ b/library/java/net/openid/appauth/Utils.java
@@ -15,6 +15,7 @@
 package net.openid.appauth;
 
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -48,9 +49,9 @@ class Utils {
     }
 
     /**
-     * Close an input stream quietly, i.e. without throwing an exception.
+     * Close a stream quietly, i.e. without throwing an exception.
      */
-    public static void closeQuietly(InputStream in) {
+    public static void closeQuietly(Closeable in) {
         try {
             if (in != null) {
                 in.close();


### PR DESCRIPTION
Mostly to remove warning about opened `OutputStream` in `TokenRequestTask`