### PR TITLE
Handle ActivityNotFoundException.

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -215,8 +215,10 @@ public class AuthorizationManagementActivity extends Activity {
          */
 
         if (!mAuthorizationStarted) {
-            startActivity(mAuthIntent);
-            mAuthorizationStarted = true;
+            if (mAuthIntent.resolveActivity(getPackageManager()) != null) {
+                startActivity(mAuthIntent);
+                mAuthorizationStarted = true;
+            }
             return;
         }
 


### PR DESCRIPTION
Resolves issue #459.

This is the same as the common behaviour in Google apps when the default browser is disabled: do nothing.