### PR TITLE
Fix idToken validation rules reference

### DIFF
--- a/library/java/net/openid/appauth/IdToken.java
+++ b/library/java/net/openid/appauth/IdToken.java
@@ -197,7 +197,7 @@ class IdToken {
         // OpenID Connect Core Section 3.1.3.7. rules #12
         // ACR is not directly supported by AppAuth.
 
-        // OpenID Connect Core Section 3.1.3.7. rules #12
+        // OpenID Connect Core Section 3.1.3.7. rules #13
         // max_age is not directly supported by AppAuth.
     }
 


### PR DESCRIPTION
`max_age` rules should be `rules #13` according to https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation