### PR TITLE
Don't check for Intent.CATEGORY_BROWSABLE in isFullBrowser

### DIFF
--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -180,9 +180,8 @@ public final class BrowserSelector {
     }
 
     private static boolean isFullBrowser(ResolveInfo resolveInfo) {
-        // The filter must match ACTION_VIEW, CATEGORY_BROWSEABLE, and at least one scheme,
+        // The filter must match ACTION_VIEW and at least one scheme,
         if (!resolveInfo.filter.hasAction(Intent.ACTION_VIEW)
-                || !resolveInfo.filter.hasCategory(Intent.CATEGORY_BROWSABLE)
                 || resolveInfo.filter.schemesIterator() == null) {
             return false;
         }

--- a/library/javatests/net/openid/appauth/browser/BrowserSelectorTest.java
+++ b/library/javatests/net/openid/appauth/browser/BrowserSelectorTest.java
@@ -85,6 +85,15 @@ public class BrowserSelectorTest {
                     .addSignature("DolphinSignature")
                     .build();
 
+    private static final TestBrowser OPERA =
+            new TestBrowserBuilder("com.opera.browser")
+                    .addAction(Intent.ACTION_VIEW)
+                    .addScheme(SCHEME_HTTP)
+                    .addScheme(SCHEME_HTTPS)
+                    .setVersion("50")
+                    .addSignature("OperaSignature")
+                    .build();
+
     private static final TestBrowser[] NO_BROWSERS = new TestBrowser[0];
 
     @Mock Context mContext;
@@ -147,18 +156,12 @@ public class BrowserSelectorTest {
     }
 
     @Test
-    public void testSelect_ignoreBrowsersWithoutBrowseableCategory()
+    public void testSelect_acceptBrowsersWithoutBrowseableCategory()
             throws NameNotFoundException {
-        TestBrowser misconfiguredBrowser =
-                new TestBrowserBuilder("com.broken.browser")
-                        .addAction(Intent.ACTION_VIEW)
-                        .addCategory(Intent.CATEGORY_DEFAULT)
-                        .addScheme(SCHEME_HTTP)
-                        .addScheme(SCHEME_HTTPS)
-                        .build();
-        setBrowserList(misconfiguredBrowser, CHROME);
-        setBrowsersWithWarmupSupport(misconfiguredBrowser, CHROME);
-        checkSelectedBrowser(CHROME, USE_CUSTOM_TAB);
+        // Opera browser does not expose Intent.CATEGORY_BROWSABLE
+        setBrowserList(OPERA);
+        setBrowsersWithWarmupSupport(OPERA);
+        checkSelectedBrowser(OPERA, USE_CUSTOM_TAB);
     }
 
     @Test


### PR DESCRIPTION
I have seen from our company's [Sentry](https://sentry.io) that some users have been getting the `ActivityNotFoundException` error from `AppAuth-Android`. The reason is that the users are using Opera as the default browser, and `AppAuth-Android` does not seem to handle that properly.

The main reason seems to be that Opera does not expose `Intent.CATEGORY_BROWSABLE` and because of that it's not marked as a full browser and gets dropped of the browser listing.

I'm not sure if this is a good way of fixing the issue, but it at least should fix the problem. Let me know if there is some other way to handle the support for Opera.

Fixes  #452

@iainmcgin 