### PR TITLE
Force new Login Activity, clearing OLD activity. 

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -161,6 +161,8 @@ public class AuthorizationManagementActivity extends Activity {
         intent.putExtra(KEY_AUTH_REQUEST, request.jsonSerializeString());
         intent.putExtra(KEY_COMPLETE_INTENT, completeIntent);
         intent.putExtra(KEY_CANCEL_INTENT, cancelIntent);
+
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         return intent;
     }
 


### PR DESCRIPTION
There is a corner case issue when device HOME button is pressed while Custom Chrome Tab Auth UI is displayed.

Issue:
1.  Within Login application, go to the Login UI 
2.  Press HOME button (taking user back to the home launcher)
3.  Relaunch Login Application, Login activity will receive Cancel Intent.

This is due to the OnResume of the AuthorizationManagementActivity getting mAuthorizationStarted from the SavedInstance, although this is a new login attempt.