### PR TITLE
Fix error handling for http errors everywhere

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationException.java
+++ b/library/java/net/openid/appauth/AuthorizationException.java
@@ -125,6 +125,11 @@ public final class AuthorizationException extends Exception {
      */
     public static final int TYPE_OAUTH_REGISTRATION_ERROR = 4;
 
+    /**
+     * Error type when returning http error code >= 400
+     */
+    public static final int TYPE_HTTP_ERROR = 5;
+
     @VisibleForTesting
     static final String KEY_TYPE = "type";
 
@@ -497,6 +502,24 @@ public final class AuthorizationException extends Exception {
                 ex.errorDescription,
                 ex.errorUri,
                 rootCause);
+    }
+
+    /**
+     * Creates an exception based on HTTP error codes returned from HttpUrlConnection
+     * Exception includes actual error code from HttpURLConnection.getResponseStream()
+     * Errors are considered anything >= 400
+     */
+    public static AuthorizationException fromHttpError(
+            int responseCode,
+            @NonNull String responseMessage,
+            @NonNull String errorString) {
+        return new AuthorizationException(
+            TYPE_HTTP_ERROR,
+            responseCode,
+            responseMessage,
+            errorString,
+            null,
+            null);
     }
 
     /**

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -450,11 +450,16 @@ public class AuthorizationService {
                 wr.write(queryData);
                 wr.flush();
 
-                if (conn.getResponseCode() >= HttpURLConnection.HTTP_OK
-                        && conn.getResponseCode() < HttpURLConnection.HTTP_MULT_CHOICE) {
+                if (conn.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
                     is = conn.getInputStream();
                 } else {
                     is = conn.getErrorStream();
+                    String errorString = Utils.readInputStream(is);
+                    mException = AuthorizationException.fromHttpError(
+                        conn.getResponseCode(),
+                        conn.getResponseMessage(),
+                        errorString);
+                    return null;
                 }
                 String response = Utils.readInputStream(is);
                 return new JSONObject(response);
@@ -599,7 +604,17 @@ public class AuthorizationService {
                 wr.write(postData);
                 wr.flush();
 
-                is = conn.getInputStream();
+                if (conn.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
+                    is = conn.getInputStream();
+                } else {
+                    is = conn.getErrorStream();
+                    String errorString = Utils.readInputStream(is);
+                    mException = AuthorizationException.fromHttpError(
+                        conn.getResponseCode(),
+                        conn.getResponseMessage(),
+                        errorString);
+                    return null;
+                }
                 String response = Utils.readInputStream(is);
                 return new JSONObject(response);
             } catch (IOException ex) {

--- a/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
@@ -329,7 +329,18 @@ public class AuthorizationServiceConfiguration {
                 conn.setDoInput(true);
                 conn.connect();
 
-                is = conn.getInputStream();
+                if (conn.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
+                    is = conn.getInputStream();
+                } else {
+                    is = conn.getErrorStream();
+                    String errorString = Utils.readInputStream(is);
+                    mException = AuthorizationException.fromHttpError(
+                        conn.getResponseCode(),
+                        conn.getResponseMessage(),
+                        errorString);
+                    return null;
+                }
+
                 JSONObject json = new JSONObject(Utils.readInputStream(is));
 
                 AuthorizationServiceDiscovery discovery =

--- a/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
@@ -218,6 +218,25 @@ public class AuthorizationServiceConfigurationTest {
     }
 
     @Test
+    public void testServiceConfigurationRequest_withBadRequest() throws Exception {
+        InputStream is = new ByteArrayInputStream(AuthorizationServiceTest.BAD_REQUEST_RESPONSE.getBytes());
+        when(mHttpConnection.getErrorStream()).thenReturn(is);
+        when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
+        when(mHttpConnection.getResponseMessage()).thenReturn(AuthorizationServiceTest.BAD_REQUEST_ERROR_MESSAGE);
+        doFetch();
+        mCallback.waitForCallback();
+        assertBadRequest(mCallback.error);
+    }
+
+    private void assertBadRequest(AuthorizationException error) {
+        assertNotNull(error);
+        assertEquals(AuthorizationException.TYPE_HTTP_ERROR, error.type);
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, error.code);
+        assertEquals(AuthorizationServiceTest.BAD_REQUEST_ERROR_MESSAGE, error.error);
+        assertEquals(AuthorizationServiceTest.BAD_REQUEST_RESPONSE, error.errorDescription);
+    }
+
+    @Test
     public void testFetchFromUrl_missingArgument() throws Exception {
         InputStream is = new ByteArrayInputStream(TEST_JSON_MISSING_ARGUMENT.getBytes());
         when(mHttpConnection.getInputStream()).thenReturn(is);


### PR DESCRIPTION
This commit adds check for response codes >= 400 and creates a new type of response for HTTP errors.
Add tests for each area changed to handle a bad request http error.