### PR TITLE
Fix `Using access tokens` snippet in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ server. This can be done directly, by extracting the access token from a
 token response. However, in most cases, it is simpler to use the
 `performActionWithFreshTokens` utility method provided by AuthState:
 
-```
+```java
 authState.performActionWithFreshTokens(service, new AuthStateAction() {
   @Override public void execute(
       String accessToken,


### PR DESCRIPTION
The snippet code in the `Using access tokens` section didn't follow java code formatting.