### PR TITLE
fix configHash in app configuration

### DIFF
--- a/app/java/net/openid/appauthdemo/Configuration.java
+++ b/app/java/net/openid/appauthdemo/Configuration.java
@@ -183,6 +183,7 @@ public final class Configuration {
         Buffer configData = new Buffer();
         try {
             configSource.readAll(configData);
+            mConfigHash = configData.sha256().base64();
             mConfigJson = new JSONObject(configData.readString(Charset.forName("UTF-8")));
         } catch (IOException ex) {
             throw new InvalidConfigurationException(
@@ -192,7 +193,6 @@ public final class Configuration {
                     "Unable to parse configuration: " + ex.getMessage());
         }
 
-        mConfigHash = configData.sha256().base64();
         mClientId = getConfigString("client_id");
         mScope = getRequiredConfigString("authorization_scope");
         mRedirectUri = getRequiredConfigUri("redirect_uri");


### PR DESCRIPTION
In app in Configuration.java configHash didn't work, because configData.readString() remove all bytes from configData, so hash was calculated from empty string every time.