### PR TITLE
Set scope to null when refreshing the token

### DIFF
--- a/library/java/net/openid/appauth/AuthState.java
+++ b/library/java/net/openid/appauth/AuthState.java
@@ -619,7 +619,7 @@ public class AuthState {
                 mLastAuthorizationResponse.request.configuration,
                 mLastAuthorizationResponse.request.clientId)
                 .setGrantType(GrantTypeValues.REFRESH_TOKEN)
-                .setScope(mLastAuthorizationResponse.request.scope)
+                .setScope(null)
                 .setRefreshToken(mRefreshToken)
                 .setAdditionalParameters(additionalParameters)
                 .build();


### PR DESCRIPTION
This change provides parity with AppAuth-iOS.  See this PR for more details (https://github.com/openid/AppAuth-iOS/pull/301).