### PR TITLE
Invoke callback on registration response with missing parameters

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -653,9 +653,9 @@ public class AuthorizationService {
                 return;
             } catch (RegistrationResponse.MissingArgumentException ex) {
                 Logger.errorWithStack(ex, "Malformed registration response");
-                mException = AuthorizationException.fromTemplate(
+                mCallback.onRegistrationRequestCompleted(null, AuthorizationException.fromTemplate(
                         GeneralErrors.INVALID_REGISTRATION_RESPONSE,
-                        ex);
+                        ex));
                 return;
             }
             Logger.debug("Dynamic registration with %s completed",

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -100,6 +100,12 @@ public class AuthorizationServiceTest {
             + " \"application_type\": " + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\n"
             + "}";
 
+    private static final String INVALID_REGISTRATION_RESPONSE_JSON = "{\n"
+        + " \"client_id\": \"" + TEST_CLIENT_ID + "\",\n"
+        + " \"client_secret\": \"" + TEST_CLIENT_SECRET + "\",\n"
+        + " \"application_type\": " + RegistrationRequest.APPLICATION_TYPE_NATIVE + "\n"
+        + "}";
+
     private static final String INVALID_GRANT_RESPONSE_JSON = "{\n"
             + "  \"error\": \"invalid_grant\",\n"
             + "  \"error_description\": \"invalid_grant description\"\n"
@@ -408,6 +414,16 @@ public class AuthorizationServiceTest {
         mRegistrationCallback.waitForCallback();
         assertNotNull(mRegistrationCallback.error);
         assertEquals(GeneralErrors.NETWORK_ERROR, mRegistrationCallback.error);
+    }
+
+    @Test
+    public void testRegistrationRequest_MissingArgumentException() throws Exception {
+        InputStream is = new ByteArrayInputStream(INVALID_REGISTRATION_RESPONSE_JSON.getBytes());
+        when(mHttpConnection.getInputStream()).thenReturn(is);
+        mService.performRegistrationRequest(getTestRegistrationRequest(), mRegistrationCallback);
+        mRegistrationCallback.waitForCallback();
+        assertNotNull(mRegistrationCallback.error);
+        assertEquals(GeneralErrors.INVALID_REGISTRATION_RESPONSE, mRegistrationCallback.error);
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Previously the library consumer would never get notified about this
error case.