### PR TITLE
should not let developer specify the discovery endpoint url.

### DIFF
--- a/app/java/net/openid/appauthdemo/Configuration.java
+++ b/app/java/net/openid/appauthdemo/Configuration.java
@@ -61,7 +61,7 @@ public final class Configuration {
     private String mClientId;
     private String mScope;
     private Uri mRedirectUri;
-    private Uri mDiscoveryUri;
+    private Uri mIssuerUri;
     private Uri mAuthEndpointUri;
     private Uri mTokenEndpointUri;
     private Uri mRegistrationEndpointUri;
@@ -137,8 +137,8 @@ public final class Configuration {
     }
 
     @Nullable
-    public Uri getDiscoveryUri() {
-        return mDiscoveryUri;
+    public Uri getmIssuerUri() {
+        return mIssuerUri;
     }
 
     @Nullable
@@ -204,7 +204,7 @@ public final class Configuration {
                             + "exists in your app manifest.");
         }
 
-        if (getConfigString("discovery_uri") == null) {
+        if (getConfigString("issuer_uri") == null) {
             mAuthEndpointUri = getRequiredConfigWebUri("authorization_endpoint_uri");
 
             mTokenEndpointUri = getRequiredConfigWebUri("token_endpoint_uri");
@@ -214,7 +214,7 @@ public final class Configuration {
                 mRegistrationEndpointUri = getRequiredConfigWebUri("registration_endpoint_uri");
             }
         } else {
-            mDiscoveryUri = getRequiredConfigWebUri("discovery_uri");
+            mIssuerUri = getRequiredConfigWebUri("issuer_uri");
         }
 
         mHttpsRequired = mConfigJson.optBoolean("https_required", true);

--- a/app/java/net/openid/appauthdemo/LoginActivity.java
+++ b/app/java/net/openid/appauthdemo/LoginActivity.java
@@ -17,6 +17,7 @@ package net.openid.appauthdemo;
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -211,7 +212,7 @@ public final class LoginActivity extends AppCompatActivity {
 
         // if we are not using discovery, build the authorization service configuration directly
         // from the static configuration values.
-        if (mConfiguration.getDiscoveryUri() == null) {
+        if (mConfiguration.getmIssuerUri() == null) {
             Log.i(TAG, "Creating auth config from res/raw/auth_config.json");
             AuthorizationServiceConfiguration config = new AuthorizationServiceConfiguration(
                     mConfiguration.getAuthEndpointUri(),
@@ -227,10 +228,8 @@ public final class LoginActivity extends AppCompatActivity {
         // noinspection WrongThread
         runOnUiThread(() -> displayLoading("Retrieving discovery document"));
         Log.i(TAG, "Retrieving OpenID discovery doc");
-        AuthorizationServiceConfiguration.fetchFromUrl(
-                mConfiguration.getDiscoveryUri(),
-                this::handleConfigurationRetrievalResult,
-                mConfiguration.getConnectionBuilder());
+        AuthorizationServiceConfiguration.fetchFromIssuer(
+            mConfiguration.getmIssuerUri(), this::handleConfigurationRetrievalResult);
     }
 
     @MainThread

--- a/app/res/raw/auth_config.json
+++ b/app/res/raw/auth_config.json
@@ -2,7 +2,7 @@
   "client_id": "",
   "redirect_uri": "net.openid.appauthdemo:/oauth2redirect",
   "authorization_scope": "openid email profile",
-  "discovery_uri": "",
+  "issuer_uri": "",
   "authorization_endpoint_uri": "",
   "token_endpoint_uri": "",
   "registration_endpoint_uri": "",


### PR DESCRIPTION
Discovery endpoint url should always be **[issuer]/.well-known/openid-configuration**
And the discovery endpoint call should be using `_fetchFromIssuer_` instead of `_fetchFromUrl_`