### PR TITLE
Add package visibility manifest query for accessing browsers on sdk 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,26 +51,6 @@ either through custom URI scheme redirects, or App Links.
 AS's that assume all clients are web-based or require clients to maintain
 confidentiality of the client secrets may not work well.
 
-From Android API 30 (R) and above, set [queries](https://developer.android.com/preview/privacy/package-visibility) in the manifest,
-to enable AppAuth searching for usable installed browsers.
-```xml
-<manifest package="com.example.game">
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="https" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.APP_BROWSER" />
-            <data android:scheme="https" />
-        </intent>
-    </queries>
-    ...
-</manifest>
-```
-
 ## Demo app
 
 A demo app is contained within this repository. For instructions on how to

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -17,19 +17,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="https" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.APP_BROWSER" />
-            <data android:scheme="https" />
-        </intent>
-    </queries>
-
     <application
             android:allowBackup="false"
             android:fullBackupContent="false"

--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -33,4 +33,12 @@
     </activity>
   </application>
 
+  <queries>
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" />
+    </intent>
+  </queries>
+
 </manifest>

--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -182,8 +182,7 @@ public final class BrowserSelector {
     private static boolean isFullBrowser(ResolveInfo resolveInfo) {
         // The filter must match ACTION_VIEW, CATEGORY_BROWSEABLE, and at least one scheme,
         if (!resolveInfo.filter.hasAction(Intent.ACTION_VIEW)
-                || !(resolveInfo.filter.hasCategory(Intent.CATEGORY_BROWSABLE)
-                    || (resolveInfo.filter.hasCategory(Intent.CATEGORY_APP_BROWSER)))
+                || !resolveInfo.filter.hasCategory(Intent.CATEGORY_BROWSABLE)
                 || resolveInfo.filter.schemesIterator() == null) {
             return false;
         }


### PR DESCRIPTION
While this item was addressed in https://github.com/openid/AppAuth-Android/pull/558/ having integrators manually add the query is not ideal.

This PR adds the query in the library manifest and lets the compile process merge it in the resulting package removing the extra integration step.

Thanks for @chrisbanes for also raising awareness on the topic in https://github.com/openid/AppAuth-Android/issues/599

To note that checking BROWSABLE is enough, as Custom Tabs is just a subset of those packages : https://developer.android.com/training/basics/intents/package-visibility-use-cases#check-browser-available