### PR TITLE
Update TokenActivity.java

### DIFF
--- a/app/java/net/openid/appauthdemo/TokenActivity.java
+++ b/app/java/net/openid/appauthdemo/TokenActivity.java
@@ -361,8 +361,9 @@ public class TokenActivity extends AppCompatActivity {
 
         mExecutor.submit(() -> {
             try {
-                HttpURLConnection conn =
-                        (HttpURLConnection) userInfoEndpoint.openConnection();
+                Configuration config = Configuration.getInstance(this);
+                Uri uri = Uri.parse(userInfoEndpoint.toString());
+                HttpURLConnection conn = config.getConnectionBuilder().openConnection(uri);
                 conn.setRequestProperty("Authorization", "Bearer " + accessToken);
                 conn.setInstanceFollowRedirects(false);
                 String response = Okio.buffer(Okio.source(conn.getInputStream()))


### PR DESCRIPTION
In the case of private SSL, it has been improved to ignore the part where user information cannot be obtained because the SSL verification cannot be ignored.