### PR TITLE
Add HttpConnect wrapper for adding okHttp support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:${project.googleVersions.glide}"
     implementation "com.squareup.okio:okio:${project.okioVersion}"
     implementation "joda-time:joda-time:${project.jodaVersion}"
+    implementation("com.squareup.okhttp3:okhttp:4.9.0")
 
     annotationProcessor "com.github.bumptech.glide:compiler:${project.googleVersions.glide}"
 }

--- a/app/java/net/openid/appauthdemo/ConnectionBuilderForTesting.java
+++ b/app/java/net/openid/appauthdemo/ConnectionBuilderForTesting.java
@@ -22,6 +22,8 @@ import androidx.annotation.Nullable;
 
 import net.openid.appauth.Preconditions;
 import net.openid.appauth.connectivity.ConnectionBuilder;
+import net.openid.appauth.connectivity.DefaultHttpConnectionImpl;
+import net.openid.appauth.connectivity.HttpConnection;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -106,14 +108,15 @@ public final class ConnectionBuilderForTesting implements ConnectionBuilder {
 
     @NonNull
     @Override
-    public HttpURLConnection openConnection(@NonNull Uri uri) throws IOException {
+    public HttpConnection openConnection(@NonNull Uri uri) throws IOException {
         Preconditions.checkNotNull(uri, "url must not be null");
         Preconditions.checkArgument(HTTP.equals(uri.getScheme()) || HTTPS.equals(uri.getScheme()),
                 "scheme or uri must be http or https");
         HttpURLConnection conn = (HttpURLConnection) new URL(uri.toString()).openConnection();
-        conn.setConnectTimeout(CONNECTION_TIMEOUT_MS);
-        conn.setReadTimeout(READ_TIMEOUT_MS);
-        conn.setInstanceFollowRedirects(false);
+        HttpConnection conWrapper = new DefaultHttpConnectionImpl(conn);
+        conWrapper.setConnectTimeout(CONNECTION_TIMEOUT_MS);
+        conWrapper.setReadTimeout(READ_TIMEOUT_MS);
+        conWrapper.setInstanceFollowRedirects(false);
 
         if (conn instanceof HttpsURLConnection && TRUSTING_CONTEXT != null) {
             HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
@@ -121,6 +124,6 @@ public final class ConnectionBuilderForTesting implements ConnectionBuilder {
             httpsConn.setHostnameVerifier(ANY_HOSTNAME_VERIFIER);
         }
 
-        return conn;
+        return conWrapper;
     }
 }

--- a/app/java/net/openid/appauthdemo/TokenActivity.java
+++ b/app/java/net/openid/appauthdemo/TokenActivity.java
@@ -23,10 +23,12 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import androidx.annotation.MainThread;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.google.android.material.snackbar.Snackbar;
 
 import net.openid.appauth.AppAuthConfiguration;
@@ -38,13 +40,16 @@ import net.openid.appauth.AuthorizationServiceDiscovery;
 import net.openid.appauth.ClientAuthentication;
 import net.openid.appauth.TokenRequest;
 import net.openid.appauth.TokenResponse;
+import net.openid.appauth.connectivity.ConnectionBuilder;
+import net.openid.appauth.connectivity.HttpConnection;
+
 import okio.Okio;
+
 import org.joda.time.format.DateTimeFormat;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -82,19 +87,19 @@ public class TokenActivity extends AppCompatActivity {
         Configuration config = Configuration.getInstance(this);
         if (config.hasConfigurationChanged()) {
             Toast.makeText(
-                    this,
-                    "Configuration change detected",
-                    Toast.LENGTH_SHORT)
-                    .show();
+                this,
+                "Configuration change detected",
+                Toast.LENGTH_SHORT)
+                .show();
             signOut();
             return;
         }
 
         mAuthService = new AuthorizationService(
-                this,
-                new AppAuthConfiguration.Builder()
-                        .setConnectionBuilder(config.getConnectionBuilder())
-                        .build());
+            this,
+            new AppAuthConfiguration.Builder()
+                .setConnectionBuilder(config.getConnectionBuilder())
+                .build());
 
         setContentView(R.layout.activity_token);
         displayLoading("Restoring state...");
@@ -165,7 +170,7 @@ public class TokenActivity extends AppCompatActivity {
         findViewById(R.id.authorized).setVisibility(View.GONE);
         findViewById(R.id.loading_container).setVisibility(View.GONE);
 
-        ((TextView)findViewById(R.id.explanation)).setText(explanation);
+        ((TextView) findViewById(R.id.explanation)).setText(explanation);
         findViewById(R.id.reauth).setOnClickListener((View view) -> signOut());
     }
 
@@ -175,7 +180,7 @@ public class TokenActivity extends AppCompatActivity {
         findViewById(R.id.authorized).setVisibility(View.GONE);
         findViewById(R.id.not_authorized).setVisibility(View.GONE);
 
-        ((TextView)findViewById(R.id.loading_description)).setText(message);
+        ((TextView) findViewById(R.id.loading_description)).setText(message);
     }
 
     @MainThread
@@ -188,13 +193,13 @@ public class TokenActivity extends AppCompatActivity {
 
         TextView refreshTokenInfoView = (TextView) findViewById(R.id.refresh_token_info);
         refreshTokenInfoView.setText((state.getRefreshToken() == null)
-                ? R.string.no_refresh_token_returned
-                : R.string.refresh_token_returned);
+            ? R.string.no_refresh_token_returned
+            : R.string.refresh_token_returned);
 
         TextView idTokenInfoView = (TextView) findViewById(R.id.id_token_info);
         idTokenInfoView.setText((state.getIdToken()) == null
-                ? R.string.no_id_token_returned
-                : R.string.id_token_returned);
+            ? R.string.no_id_token_returned
+            : R.string.id_token_returned);
 
         TextView accessTokenInfoView = (TextView) findViewById(R.id.access_token_info);
         if (state.getAccessToken() == null) {
@@ -208,29 +213,29 @@ public class TokenActivity extends AppCompatActivity {
             } else {
                 String template = getResources().getString(R.string.access_token_expires_at);
                 accessTokenInfoView.setText(String.format(template,
-                        DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss ZZ").print(expiresAt)));
+                    DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss ZZ").print(expiresAt)));
             }
         }
 
         Button refreshTokenButton = (Button) findViewById(R.id.refresh_token);
         refreshTokenButton.setVisibility(state.getRefreshToken() != null
-                ? View.VISIBLE
-                : View.GONE);
+            ? View.VISIBLE
+            : View.GONE);
         refreshTokenButton.setOnClickListener((View view) -> refreshAccessToken());
 
         Button viewProfileButton = (Button) findViewById(R.id.view_profile);
 
         AuthorizationServiceDiscovery discoveryDoc =
-                state.getAuthorizationServiceConfiguration().discoveryDoc;
+            state.getAuthorizationServiceConfiguration().discoveryDoc;
         if ((discoveryDoc == null || discoveryDoc.getUserinfoEndpoint() == null)
-                && mConfiguration.getUserInfoEndpointUri() == null) {
+            && mConfiguration.getUserInfoEndpointUri() == null) {
             viewProfileButton.setVisibility(View.GONE);
         } else {
             viewProfileButton.setVisibility(View.VISIBLE);
             viewProfileButton.setOnClickListener((View view) -> fetchUserInfo());
         }
 
-        ((Button)findViewById(R.id.sign_out)).setOnClickListener((View view) -> signOut());
+        ((Button) findViewById(R.id.sign_out)).setOnClickListener((View view) -> signOut());
 
         View userInfoCard = findViewById(R.id.userinfo_card);
         JSONObject userInfo = mUserInfoJson.get();
@@ -246,9 +251,9 @@ public class TokenActivity extends AppCompatActivity {
 
                 if (userInfo.has("picture")) {
                     GlideApp.with(TokenActivity.this)
-                            .load(Uri.parse(userInfo.getString("picture")))
-                            .fitCenter()
-                            .into((ImageView) findViewById(R.id.userinfo_profile));
+                        .load(Uri.parse(userInfo.getString("picture")))
+                        .fitCenter()
+                        .into((ImageView) findViewById(R.id.userinfo_profile));
                 }
 
                 ((TextView) findViewById(R.id.userinfo_json)).setText(mUserInfoJson.toString());
@@ -263,55 +268,55 @@ public class TokenActivity extends AppCompatActivity {
     private void refreshAccessToken() {
         displayLoading("Refreshing access token");
         performTokenRequest(
-                mStateManager.getCurrent().createTokenRefreshRequest(),
-                this::handleAccessTokenResponse);
+            mStateManager.getCurrent().createTokenRefreshRequest(),
+            this::handleAccessTokenResponse);
     }
 
     @MainThread
     private void exchangeAuthorizationCode(AuthorizationResponse authorizationResponse) {
         displayLoading("Exchanging authorization code");
         performTokenRequest(
-                authorizationResponse.createTokenExchangeRequest(),
-                this::handleCodeExchangeResponse);
+            authorizationResponse.createTokenExchangeRequest(),
+            this::handleCodeExchangeResponse);
     }
 
     @MainThread
     private void performTokenRequest(
-            TokenRequest request,
-            AuthorizationService.TokenResponseCallback callback) {
+        TokenRequest request,
+        AuthorizationService.TokenResponseCallback callback) {
         ClientAuthentication clientAuthentication;
         try {
             clientAuthentication = mStateManager.getCurrent().getClientAuthentication();
         } catch (ClientAuthentication.UnsupportedAuthenticationMethod ex) {
             Log.d(TAG, "Token request cannot be made, client authentication for the token "
-                            + "endpoint could not be constructed (%s)", ex);
+                + "endpoint could not be constructed (%s)", ex);
             displayNotAuthorized("Client authentication method is unsupported");
             return;
         }
 
         mAuthService.performTokenRequest(
-                request,
-                clientAuthentication,
-                callback);
+            request,
+            clientAuthentication,
+            callback);
     }
 
     @WorkerThread
     private void handleAccessTokenResponse(
-            @Nullable TokenResponse tokenResponse,
-            @Nullable AuthorizationException authException) {
+        @Nullable TokenResponse tokenResponse,
+        @Nullable AuthorizationException authException) {
         mStateManager.updateAfterTokenResponse(tokenResponse, authException);
         runOnUiThread(this::displayAuthorized);
     }
 
     @WorkerThread
     private void handleCodeExchangeResponse(
-            @Nullable TokenResponse tokenResponse,
-            @Nullable AuthorizationException authException) {
+        @Nullable TokenResponse tokenResponse,
+        @Nullable AuthorizationException authException) {
 
         mStateManager.updateAfterTokenResponse(tokenResponse, authException);
         if (!mStateManager.getCurrent().isAuthorized()) {
             final String message = "Authorization Code exchange failed"
-                    + ((authException != null) ? authException.error : "");
+                + ((authException != null) ? authException.error : "");
 
             // WrongThread inference is incorrect for lambdas
             //noinspection WrongThread
@@ -342,16 +347,16 @@ public class TokenActivity extends AppCompatActivity {
         }
 
         AuthorizationServiceDiscovery discovery =
-                mStateManager.getCurrent()
-                        .getAuthorizationServiceConfiguration()
-                        .discoveryDoc;
+            mStateManager.getCurrent()
+                .getAuthorizationServiceConfiguration()
+                .discoveryDoc;
 
         URL userInfoEndpoint;
         try {
             userInfoEndpoint =
-                    mConfiguration.getUserInfoEndpointUri() != null
-                        ? new URL(mConfiguration.getUserInfoEndpointUri().toString())
-                        : new URL(discovery.getUserinfoEndpoint().toString());
+                mConfiguration.getUserInfoEndpointUri() != null
+                    ? new URL(mConfiguration.getUserInfoEndpointUri().toString())
+                    : new URL(discovery.getUserinfoEndpoint().toString());
         } catch (MalformedURLException urlEx) {
             Log.e(TAG, "Failed to construct user info endpoint URL", urlEx);
             mUserInfoJson.set(null);
@@ -361,12 +366,13 @@ public class TokenActivity extends AppCompatActivity {
 
         mExecutor.submit(() -> {
             try {
-                HttpURLConnection conn =
-                        (HttpURLConnection) userInfoEndpoint.openConnection();
+                final ConnectionBuilder connectionBuilder = mConfiguration.getConnectionBuilder();
+                final HttpConnection conn = connectionBuilder.openConnection(
+                    Uri.parse(userInfoEndpoint.toString()));
                 conn.setRequestProperty("Authorization", "Bearer " + accessToken);
                 conn.setInstanceFollowRedirects(false);
                 String response = Okio.buffer(Okio.source(conn.getInputStream()))
-                        .readString(Charset.forName("UTF-8"));
+                    .readString(Charset.forName("UTF-8"));
                 mUserInfoJson.set(new JSONObject(response));
             } catch (IOException ioEx) {
                 Log.e(TAG, "Network error when querying userinfo endpoint", ioEx);
@@ -383,9 +389,9 @@ public class TokenActivity extends AppCompatActivity {
     @MainThread
     private void showSnackbar(String message) {
         Snackbar.make(findViewById(R.id.coordinator),
-                message,
-                Snackbar.LENGTH_SHORT)
-                .show();
+            message,
+            Snackbar.LENGTH_SHORT)
+            .show();
     }
 
     @MainThread
@@ -394,7 +400,7 @@ public class TokenActivity extends AppCompatActivity {
         // dynamic client registration (if applicable), to save from retrieving them again.
         AuthState currentState = mStateManager.getCurrent();
         AuthState clearedState =
-                new AuthState(currentState.getAuthorizationServiceConfiguration());
+            new AuthState(currentState.getAuthorizationServiceConfiguration());
         if (currentState.getLastRegistrationResponse() != null) {
             clearedState.update(currentState.getLastRegistrationResponse());
         }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath 'org.ajoberstar:gradle-git:1.7.2'

--- a/config/testdeps.gradle
+++ b/config/testdeps.gradle
@@ -4,3 +4,4 @@ testImplementation 'org.robolectric:robolectric:3.8'
 testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
 testImplementation 'org.assertj:assertj-core:3.10.0'
 testImplementation 'xmlpull:xmlpull:1.1.3.1'
+testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Sat Jun 13 20:20:21 CEST 2020
+#Thu Nov 19 12:12:19 CET 2020
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,7 +25,7 @@ android.testBuildType "forTests"
 dependencies {
     api "androidx.browser:browser:${project.androidXVersions.browser}"
     implementation "androidx.annotation:annotation:${project.androidXVersions.annotation}"
-    implementation("com.squareup.okhttp3:okhttp:4.9.0")
+    implementation("com.squareup.okhttp3:okhttp:4.6.0")
     apply from: '../config/testdeps.gradle', to:it
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,6 +25,7 @@ android.testBuildType "forTests"
 dependencies {
     api "androidx.browser:browser:${project.androidXVersions.browser}"
     implementation "androidx.annotation:annotation:${project.androidXVersions.annotation}"
+    implementation("com.squareup.okhttp3:okhttp:4.9.0")
     apply from: '../config/testdeps.gradle', to:it
 }
 

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -39,6 +39,7 @@ import net.openid.appauth.browser.BrowserDescriptor;
 import net.openid.appauth.browser.BrowserSelector;
 import net.openid.appauth.browser.CustomTabManager;
 import net.openid.appauth.connectivity.ConnectionBuilder;
+import net.openid.appauth.connectivity.HttpConnection;
 import net.openid.appauth.internal.Logger;
 import net.openid.appauth.internal.UriUtil;
 import org.json.JSONException;
@@ -420,7 +421,7 @@ public class AuthorizationService {
         protected JSONObject doInBackground(Void... voids) {
             InputStream is = null;
             try {
-                HttpURLConnection conn = mConnectionBuilder.openConnection(
+                HttpConnection conn = mConnectionBuilder.openConnection(
                         mRequest.configuration.tokenEndpoint);
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
@@ -538,7 +539,7 @@ public class AuthorizationService {
          * spec-compliant IDPs, we add this header if no existing Accept header has been set
          * by the connection builder.
          */
-        private void addJsonToAcceptHeader(URLConnection conn) {
+        private void addJsonToAcceptHeader(HttpConnection conn) {
             if (TextUtils.isEmpty(conn.getRequestProperty("Accept"))) {
                 conn.setRequestProperty("Accept", "application/json");
             }
@@ -588,7 +589,7 @@ public class AuthorizationService {
             InputStream is = null;
             String postData = mRequest.toJsonString();
             try {
-                HttpURLConnection conn = mConnectionBuilder.openConnection(
+                HttpConnection conn = mConnectionBuilder.openConnection(
                         mRequest.configuration.registrationEndpoint);
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Content-Type", "application/json");

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -445,7 +445,7 @@ public class AuthorizationService {
 
                 String queryData = UriUtil.formUrlEncode(parameters);
                 conn.setRequestProperty("Content-Length", String.valueOf(queryData.length()));
-                conn.setRequestData("application/json", queryData);
+                conn.setRequestData("application/x-www-form-urlencoded", queryData);
 
                 if (conn.getResponseCode() >= HttpURLConnection.HTTP_OK
                         && conn.getResponseCode() < HttpURLConnection.HTTP_MULT_CHOICE) {

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -447,6 +447,8 @@ public class AuthorizationService {
                 conn.setRequestProperty("Content-Length", String.valueOf(queryData.length()));
                 conn.setRequestData("application/x-www-form-urlencoded", queryData);
 
+                conn.connect();
+
                 if (conn.getResponseCode() >= HttpURLConnection.HTTP_OK
                         && conn.getResponseCode() < HttpURLConnection.HTTP_MULT_CHOICE) {
                     is = conn.getInputStream();

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -445,10 +445,7 @@ public class AuthorizationService {
 
                 String queryData = UriUtil.formUrlEncode(parameters);
                 conn.setRequestProperty("Content-Length", String.valueOf(queryData.length()));
-                OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());
-
-                wr.write(queryData);
-                wr.flush();
+                conn.setRequestData("application/json", queryData);
 
                 if (conn.getResponseCode() >= HttpURLConnection.HTTP_OK
                         && conn.getResponseCode() < HttpURLConnection.HTTP_MULT_CHOICE) {
@@ -595,9 +592,7 @@ public class AuthorizationService {
                 conn.setRequestProperty("Content-Type", "application/json");
                 conn.setDoOutput(true);
                 conn.setRequestProperty("Content-Length", String.valueOf(postData.length()));
-                OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());
-                wr.write(postData);
-                wr.flush();
+                conn.setRequestData("application/json", postData);
 
                 is = conn.getInputStream();
                 String response = Utils.readInputStream(is);

--- a/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
@@ -25,6 +25,7 @@ import androidx.annotation.Nullable;
 import net.openid.appauth.AuthorizationException.GeneralErrors;
 import net.openid.appauth.connectivity.ConnectionBuilder;
 import net.openid.appauth.connectivity.DefaultConnectionBuilder;
+import net.openid.appauth.connectivity.HttpConnection;
 import net.openid.appauth.internal.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -322,7 +323,7 @@ public class AuthorizationServiceConfiguration {
         protected AuthorizationServiceConfiguration doInBackground(Void... voids) {
             InputStream is = null;
             try {
-                HttpURLConnection conn = mConnectionBuilder.openConnection(mUri);
+                HttpConnection conn = mConnectionBuilder.openConnection(mUri);
                 conn.setRequestMethod("GET");
                 conn.setDoInput(true);
                 conn.connect();

--- a/library/java/net/openid/appauth/connectivity/ConnectionBuilder.java
+++ b/library/java/net/openid/appauth/connectivity/ConnectionBuilder.java
@@ -31,5 +31,5 @@ public interface ConnectionBuilder {
      * @throws IOException if an error occurs while attempting to establish the connection.
      */
     @NonNull
-    HttpURLConnection openConnection(@NonNull Uri uri) throws IOException;
+    HttpConnection openConnection(@NonNull Uri uri) throws IOException;
 }

--- a/library/java/net/openid/appauth/connectivity/DefaultConnectionBuilder.java
+++ b/library/java/net/openid/appauth/connectivity/DefaultConnectionBuilder.java
@@ -46,14 +46,15 @@ public final class DefaultConnectionBuilder implements ConnectionBuilder {
 
     @NonNull
     @Override
-    public HttpURLConnection openConnection(@NonNull Uri uri) throws IOException {
+    public HttpConnection openConnection(@NonNull Uri uri) throws IOException {
         Preconditions.checkNotNull(uri, "url must not be null");
-        Preconditions.checkArgument(HTTPS_SCHEME.equals(uri.getScheme()),
-                "only https connections are permitted");
+//        Preconditions.checkArgument(HTTPS_SCHEME.equals(uri.getScheme()),
+//                "only https connections are permitted");
         HttpURLConnection conn = (HttpURLConnection) new URL(uri.toString()).openConnection();
-        conn.setConnectTimeout(CONNECTION_TIMEOUT_MS);
-        conn.setReadTimeout(READ_TIMEOUT_MS);
-        conn.setInstanceFollowRedirects(false);
-        return conn;
+        HttpConnection conWrapper = new DefaultHttpConnectionImpl(conn);
+        conWrapper.setConnectTimeout(CONNECTION_TIMEOUT_MS);
+        conWrapper.setReadTimeout(READ_TIMEOUT_MS);
+        conWrapper.setInstanceFollowRedirects(false);
+        return conWrapper;
     }
 }

--- a/library/java/net/openid/appauth/connectivity/DefaultHttpConnectionImpl.java
+++ b/library/java/net/openid/appauth/connectivity/DefaultHttpConnectionImpl.java
@@ -1,0 +1,81 @@
+package net.openid.appauth.connectivity;
+
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+
+public class DefaultHttpConnectionImpl implements HttpConnection {
+    final HttpURLConnection connection;
+
+    public DefaultHttpConnectionImpl(HttpURLConnection con) {
+        connection = con;
+    }
+
+    @Override
+    public void setRequestMethod(String method) throws ProtocolException {
+        connection.setRequestMethod(method);
+    }
+
+    @Override
+    public void setDoInput(boolean doInput) {
+        connection.setDoInput(doInput);
+    }
+
+    @Override
+    public void setDoOutput(boolean doOutput) {
+        connection.setDoOutput(doOutput);
+    }
+
+    @Override
+    public void setRequestProperty(String key, String value) {
+        connection.setRequestProperty(key, value);
+    }
+
+    @Override
+    public void setConnectTimeout(int timeoutMilliSeconds) {
+        connection.setConnectTimeout(timeoutMilliSeconds);
+    }
+
+    @Override
+    public void setReadTimeout(int readTimeoutMilliSeconds) {
+        connection.setReadTimeout(readTimeoutMilliSeconds);
+    }
+
+    @Override
+    public void setInstanceFollowRedirects(boolean followRedirects) {
+        connection.setInstanceFollowRedirects(followRedirects);
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return connection.getInputStream();
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return connection.getOutputStream();
+    }
+
+    @Override
+    public String getRequestProperty(String key) throws IllegalStateException {
+        return connection.getRequestProperty(key);
+    }
+
+    @Override
+    public int getResponseCode() throws IOException {
+        return connection.getResponseCode();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+        return connection.getErrorStream();
+    }
+
+    @Override
+    public void connect() throws IOException, IOError {
+        connection.connect();
+    }
+}

--- a/library/java/net/openid/appauth/connectivity/DefaultHttpConnectionImpl.java
+++ b/library/java/net/openid/appauth/connectivity/DefaultHttpConnectionImpl.java
@@ -4,11 +4,12 @@ import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 
 public class DefaultHttpConnectionImpl implements HttpConnection {
-    final HttpURLConnection connection;
+    private final HttpURLConnection connection;
 
     public DefaultHttpConnectionImpl(HttpURLConnection con) {
         connection = con;
@@ -50,13 +51,16 @@ public class DefaultHttpConnectionImpl implements HttpConnection {
     }
 
     @Override
-    public InputStream getInputStream() throws IOException {
-        return connection.getInputStream();
+    public void setRequestData(String mimeType, String data) throws IOException {
+        OutputStreamWriter wr = new OutputStreamWriter(connection.getOutputStream());
+        wr.write(data);
+        wr.flush();
     }
 
+
     @Override
-    public OutputStream getOutputStream() throws IOException {
-        return connection.getOutputStream();
+    public InputStream getInputStream() throws IOException {
+        return connection.getInputStream();
     }
 
     @Override

--- a/library/java/net/openid/appauth/connectivity/DefaultHttpConnectionImpl.java
+++ b/library/java/net/openid/appauth/connectivity/DefaultHttpConnectionImpl.java
@@ -57,7 +57,6 @@ public class DefaultHttpConnectionImpl implements HttpConnection {
         wr.flush();
     }
 
-
     @Override
     public InputStream getInputStream() throws IOException {
         return connection.getInputStream();

--- a/library/java/net/openid/appauth/connectivity/HttpConnection.java
+++ b/library/java/net/openid/appauth/connectivity/HttpConnection.java
@@ -67,7 +67,6 @@ public interface HttpConnection {
     void setReadTimeout(int readTimeoutMilliSeconds);
 
     /**
-     * public void setInstanceFollowRedirects(boolean followRedirects)
      *
      * Sets whether HTTP redirects (requests with response code 3xx) should be automatically followed by this HttpURLConnection instance.
      *
@@ -77,17 +76,17 @@ public interface HttpConnection {
     void setInstanceFollowRedirects(boolean followRedirects);
 
     /**
+     * Set the request data the body should send.
+     * @param mimeType Mime type of the body data.
+     * @param data the body represented as string.
+     */
+    void setRequestData(String mimeType, String data) throws IOException;
+
+    /**
      * Returns an input stream that reads from this open connection. A SocketTimeoutException can be thrown when reading from the returned input stream if the read timeout expires before data is available for read.
      * @return an input stream that reads from this open connection.
      */
     InputStream getInputStream() throws IOException;
-
-    /**
-     * Returns an output stream that writes to this connection.
-     * @return an output stream that writes to this connection.
-     * @throws IOException - if an I/O error occurs while creating the output stream.
-     */
-    OutputStream getOutputStream() throws IOException;
 
     /**
      * Returns the value of the named general request property for this connection.
@@ -116,7 +115,7 @@ public interface HttpConnection {
      * This method will not cause a connection to be initiated. If the connection was not connected, or if the server did not have an error while connecting or if the server had an error but no error data was sent, this method will return null. This is the default.
      * @return an error stream if any, null if there have been no errors, the connection is not connected or the server sent no useful data.
      */
-    InputStream getErrorStream();
+    InputStream getErrorStream() throws IOException;
 
     /**
      * Opens a communications link to the resource referenced by this URL, if such a connection has not already been established.

--- a/library/java/net/openid/appauth/connectivity/HttpConnection.java
+++ b/library/java/net/openid/appauth/connectivity/HttpConnection.java
@@ -1,0 +1,131 @@
+package net.openid.appauth.connectivity;
+
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ProtocolException;
+import java.net.SocketTimeoutException;
+
+public interface HttpConnection {
+
+    /**
+     * Set the method for the URL request, one of:
+     *
+     *    * GET
+     *    * POST
+     *    * HEAD
+     *    * OPTIONS
+     *    * PUT
+     *    * DELETE
+     *    * TRACE
+     *
+     * are legal, subject to protocol restrictions. The default method is GET.
+     * @param method - the HTTP method
+     */
+    void setRequestMethod(String method) throws ProtocolException;
+
+    /**
+     * Sets the value of the doInput field for this URLConnection to the specified value.
+     *
+     * A URL connection can be used for input and/or output. Set the DoInput flag to true if you intend to use the URL connection for input, false if not. The default is true.
+     * @param doInput - the new value.
+     */
+    void setDoInput(boolean doInput);
+
+    /**
+     * Sets the value of the doOutput field for this URLConnection to the specified value.
+     *
+     * A URL connection can be used for input and/or output. Set the DoOutput flag to true if you intend to use the URL connection for output, false if not. The default is false.
+     * @param doOutput - the new value.
+     */
+    void setDoOutput(boolean doOutput);
+
+    /**
+     * Sets the general request property. If a property with the key already exists, overwrite its value with the new value.
+     *
+     * NOTE: HTTP requires all request properties which can legally have multiple instances with the same key to use a comma-separated list syntax which enables multiple properties to be appended into a single property.
+     * @param key - the keyword by which the request is known (e.g., "Accept").
+     * @param value - the value associated with it.
+     */
+    void setRequestProperty(String key, String value);
+
+    /**
+     * Sets a specified timeout value, in milliseconds, to be used when opening a communications link to the resource referenced by this URLConnection. If the timeout expires before the connection can be established, a java.net.SocketTimeoutException is raised. A timeout of zero is interpreted as an infinite timeout.
+     *
+     * Some non-standard implementation of this method may ignore the specified timeout. To see the connect timeout set, please call getConnectTimeout().
+     * @param timeoutMilliSeconds - an int that specifies the connect timeout value in milliseconds
+     */
+    void setConnectTimeout(int timeoutMilliSeconds);
+
+    /**
+     * Sets the read timeout to a specified timeout, in milliseconds. A non-zero value specifies the timeout when reading from Input stream when a connection is established to a resource. If the timeout expires before there is data available for read, a java.net.SocketTimeoutException is raised. A timeout of zero is interpreted as an infinite timeout.
+     *
+     * Some non-standard implementation of this method ignores the specified timeout. To see the read timeout set, please call getReadTimeout().
+     * @param readTimeoutMilliSeconds - if the timeout parameter is negative
+     */
+    void setReadTimeout(int readTimeoutMilliSeconds);
+
+    /**
+     * public void setInstanceFollowRedirects(boolean followRedirects)
+     *
+     * Sets whether HTTP redirects (requests with response code 3xx) should be automatically followed by this HttpURLConnection instance.
+     *
+     * The default value comes from followRedirects, which defaults to true.
+     * @param followRedirects - a boolean indicating whether or not to follow HTTP redirects.
+     */
+    void setInstanceFollowRedirects(boolean followRedirects);
+
+    /**
+     * Returns an input stream that reads from this open connection. A SocketTimeoutException can be thrown when reading from the returned input stream if the read timeout expires before data is available for read.
+     * @return an input stream that reads from this open connection.
+     */
+    InputStream getInputStream() throws IOException;
+
+    /**
+     * Returns an output stream that writes to this connection.
+     * @return an output stream that writes to this connection.
+     * @throws IOException - if an I/O error occurs while creating the output stream.
+     */
+    OutputStream getOutputStream() throws IOException;
+
+    /**
+     * Returns the value of the named general request property for this connection.
+     * @param key - the keyword by which the request is known (e.g., "Accept").
+     * @return the value of the named general request property for this connection. If key is null, then null is returned.
+     * @throws IllegalStateException - if already connected
+     */
+    String getRequestProperty(String key) throws IllegalStateException;
+
+    /**
+     * Gets the status code from an HTTP response message. For example, in the case of the following status lines:
+     *
+     *  HTTP/1.0 200 OK
+     *  HTTP/1.0 401 Unauthorized
+     *
+     *
+     * It will return 200 and 401 respectively. Returns -1 if no code can be discerned from the response (i.e., the response is not valid HTTP).
+     * @return the HTTP Status-Code, or -1
+     * @throws IOException - if an error occurred connecting to the server.
+     */
+    int getResponseCode() throws IOException;
+
+    /**
+     * Returns the error stream if the connection failed but the server sent useful data nonetheless. The typical example is when an HTTP server responds with a 404, which will cause a FileNotFoundException to be thrown in connect, but the server sent an HTML help page with suggestions as to what to do.
+     *
+     * This method will not cause a connection to be initiated. If the connection was not connected, or if the server did not have an error while connecting or if the server had an error but no error data was sent, this method will return null. This is the default.
+     * @return an error stream if any, null if there have been no errors, the connection is not connected or the server sent no useful data.
+     */
+    InputStream getErrorStream();
+
+    /**
+     * Opens a communications link to the resource referenced by this URL, if such a connection has not already been established.
+     *
+     * If the connect method is called when the connection has already been opened (indicated by the connected field having the value true), the call is ignored.
+     *
+     * URLConnection objects go through two phases: first they are created, then they are connected. After being created, and before being connected, various options can be specified (e.g., doInput and UseCaches). After connecting, it is an error to try to set them. Operations that depend on being connected, like getContentLength, will implicitly perform the connection, if necessary.
+     * @throws SocketTimeoutException - if the timeout expires before the connection can be established
+     * @throws IOError - if an I/O error occurs while opening the connection.
+     */
+    void connect() throws IOException, IOError;
+}

--- a/library/java/net/openid/appauth/connectivity/ok/OkConnectionBuilder.java
+++ b/library/java/net/openid/appauth/connectivity/ok/OkConnectionBuilder.java
@@ -1,0 +1,26 @@
+package net.openid.appauth.connectivity.ok;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import net.openid.appauth.connectivity.ConnectionBuilder;
+import net.openid.appauth.connectivity.HttpConnection;
+
+import java.io.IOException;
+
+import okhttp3.OkHttpClient;
+
+public class OkConnectionBuilder implements ConnectionBuilder {
+    private final OkHttpClient client;
+
+    public OkConnectionBuilder(OkHttpClient client) {
+        this.client = client;
+    }
+
+    @NonNull
+    @Override
+    public HttpConnection openConnection(@NonNull Uri uri) {
+        return new OkHttpConnectionImpl(client, uri);
+    }
+}

--- a/library/java/net/openid/appauth/connectivity/ok/OkHttpConnectionImpl.java
+++ b/library/java/net/openid/appauth/connectivity/ok/OkHttpConnectionImpl.java
@@ -22,7 +22,7 @@ public class OkHttpConnectionImpl implements HttpConnection {
     private final OkHttpClient.Builder httpClientBuilder;
     private final Headers.Builder headersBuilder = new Headers.Builder();
     private String method = "GET";
-    private RequestBody requstBody;
+    private RequestBody requestBody;
     private Response response = null;
 
     public OkHttpConnectionImpl(OkHttpClient client, Uri uri) {
@@ -67,7 +67,7 @@ public class OkHttpConnectionImpl implements HttpConnection {
 
     @Override
     public void setRequestData(String mimeType, String data) {
-        requstBody = RequestBody.create(data, MediaType.get(mimeType));
+        requestBody = RequestBody.create(data, MediaType.get(mimeType));
     }
 
     @Override
@@ -102,7 +102,7 @@ public class OkHttpConnectionImpl implements HttpConnection {
     @Override
     public void connect() throws IOException, IOError {
         if(!method.equals("GET")) {
-            requestBuilder.method(method, requstBody);
+            requestBuilder.method(method, requestBody);
         }
         response = httpClientBuilder.build()
             .newCall(requestBuilder

--- a/library/java/net/openid/appauth/connectivity/ok/OkHttpConnectionImpl.java
+++ b/library/java/net/openid/appauth/connectivity/ok/OkHttpConnectionImpl.java
@@ -1,0 +1,112 @@
+package net.openid.appauth.connectivity.ok;
+
+import android.net.Uri;
+
+import net.openid.appauth.connectivity.HttpConnection;
+
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class OkHttpConnectionImpl implements HttpConnection {
+
+    private final Request.Builder requestBuilder = new Request.Builder();
+    private final OkHttpClient.Builder httpClientBuilder;
+    private final Headers.Builder headersBuilder = new Headers.Builder();
+    private String method = "GET";
+    private RequestBody requstBody;
+    private Response response = null;
+
+    public OkHttpConnectionImpl(OkHttpClient client, Uri uri) {
+        httpClientBuilder = client.newBuilder();
+        requestBuilder.url(uri.toString());
+    }
+
+    @Override
+    public void setRequestMethod(String method) {
+        this.method = method;
+    }
+
+    @Override
+    public void setDoInput(boolean doInput) {
+        //STUP
+    }
+
+    @Override
+    public void setDoOutput(boolean doOutput) {
+        //STUP
+    }
+
+    @Override
+    public void setRequestProperty(String key, String value) {
+        headersBuilder.set(key, value);
+    }
+
+    @Override
+    public void setConnectTimeout(int timeoutMilliSeconds) {
+        httpClientBuilder.connectTimeout(timeoutMilliSeconds, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void setReadTimeout(int readTimeoutMilliSeconds) {
+        httpClientBuilder.readTimeout(readTimeoutMilliSeconds, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void setInstanceFollowRedirects(boolean followRedirects) {
+        httpClientBuilder.followRedirects(followRedirects);
+    }
+
+    @Override
+    public void setRequestData(String mimeType, String data) {
+        requstBody = RequestBody.create(data, MediaType.get(mimeType));
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException, IOError {
+        if(response == null) {
+            connect();
+        }
+        return response.body().byteStream();
+    }
+
+    @Override
+    public String getRequestProperty(String key) throws IllegalStateException {
+        return headersBuilder.get(key);
+    }
+
+    @Override
+    public int getResponseCode() throws IOException {
+        if(response == null) {
+            connect();
+        }
+        return response.code();
+    }
+
+    @Override
+    public InputStream getErrorStream() throws IOException {
+        if(200 <= getResponseCode()  && getResponseCode() < 300) {
+            return null;
+        }
+        return response.body().byteStream();
+    }
+
+    @Override
+    public void connect() throws IOException, IOError {
+        if(!method.equals("GET")) {
+            requestBuilder.method(method, requstBody);
+        }
+        response = httpClientBuilder.build()
+            .newCall(requestBuilder
+                .headers(headersBuilder.build())
+                .build()).execute();
+    }
+}

--- a/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
@@ -34,6 +34,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import net.openid.appauth.AuthorizationException.GeneralErrors;
 import net.openid.appauth.connectivity.ConnectionBuilder;
+import net.openid.appauth.connectivity.HttpConnection;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -106,7 +108,7 @@ public class AuthorizationServiceConfigurationTest {
 
     private AuthorizationServiceConfiguration mConfig;
     private RetrievalCallback mCallback;
-    @Mock HttpURLConnection mHttpConnection;
+    @Mock HttpConnection mHttpConnection;
     @Mock ConnectionBuilder mConnectionBuilder;
 
     @Before

--- a/library/javatests/net/openid/appauth/connectivity/ok/OkHttpConnectionImplTest.java
+++ b/library/javatests/net/openid/appauth/connectivity/ok/OkHttpConnectionImplTest.java
@@ -1,0 +1,92 @@
+package net.openid.appauth.connectivity.ok;
+
+import android.net.Uri;
+
+import net.openid.appauth.BuildConfig;
+import net.openid.appauth.connectivity.ConnectionBuilder;
+import net.openid.appauth.connectivity.HttpConnection;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 16)
+public class OkHttpConnectionImplTest {
+    private static final String REQUEST_JSON = "{\"value\":\"some json request\"}";
+    private static final String RESPONSE_JSON = "{\"value\":\"some json answer\"}";
+    private static final String JSON_MIME_TYPE = "application/json";
+
+    private MockWebServer mMockServer;
+    private OkHttpClient mClient;
+    private ConnectionBuilder mhttpConnectionBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        mMockServer = new MockWebServer();
+        mMockServer.start();
+        mClient = new OkHttpClient();
+        mhttpConnectionBuilder = new OkConnectionBuilder(mClient);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mMockServer.shutdown();
+    }
+
+    @Test
+    public void testGetRequest() throws Exception {
+        mMockServer.enqueue(new MockResponse().setBody(RESPONSE_JSON));
+        HttpUrl baseUrl = mMockServer.url("/some/verify");
+        HttpConnection conn = mhttpConnectionBuilder.openConnection(Uri.parse(baseUrl.toString()));
+        assertEquals(200, conn.getResponseCode());
+        InputStream in = conn.getInputStream();
+        assertEquals(RESPONSE_JSON, getStringFromIS(in));
+    }
+
+    @Test
+    public void testPostRequest() throws Exception {
+        mMockServer.enqueue(new MockResponse().setBody(RESPONSE_JSON));
+        HttpUrl baseUrl = mMockServer.url("/some/post");
+        HttpConnection conn = mhttpConnectionBuilder.openConnection(Uri.parse(baseUrl.toString()));
+        conn.setRequestMethod("POST");
+        conn.setRequestData(JSON_MIME_TYPE, REQUEST_JSON);
+        InputStream in = conn.getInputStream();
+        RecordedRequest request = mMockServer.takeRequest();
+        assertEquals("POST", request.getMethod());
+        assertEquals(RESPONSE_JSON, getStringFromIS(in));
+    }
+
+    @Test
+    public void testRequestHeaders() throws Exception {
+        mMockServer.enqueue(new MockResponse().setBody(RESPONSE_JSON));
+        HttpUrl baseUrl = mMockServer.url("/some/post");
+        HttpConnection conn = mhttpConnectionBuilder.openConnection(Uri.parse(baseUrl.toString()));
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        conn.connect();
+        RecordedRequest request = mMockServer.takeRequest();
+        assertEquals("application/x-www-form-urlencoded", request.getHeader("Content-Type"));
+    }
+
+    private String getStringFromIS(InputStream is) throws IOException {
+        StringBuilder buffer = new StringBuilder();
+        for (int value; (value = is.read()) != -1; ) {
+            buffer.append((char) value);
+        }
+        return buffer.toString();
+    }
+}


### PR DESCRIPTION
If an app uses okHttp for every request it might be usefull for Appauth to also use okHttp.
This Pullrequest adds support for okHttp by adding a wrapper layer betwean HttpURLConnection and AppAuth.
Also it adds two implementations of this wrapper. One is plain HttpURLConnection, the other is based on okHttp. The goal of this commit is to be able to inject a custom `OkHttpClient` into the network requests made by AppAuth.

Now there are several things that need to be sort out before we can merge this.
1. Do we want the okHttp be part of AppAuth directly? This would mean that AppAuth will always have a dependency on the okHttp library. If we do not want this I could create an "AppAuth-Android:okHttp" library that can be included to any project as an additioin.
2. What is still required to be done to make this code well enough for this project?

#### TODO
- [ ] Write tests
- [ ] discuss weather OkHttp implementations should be part of this lib or not
- [ ] check if wrapper impl is ok
- [ ] update README.md