### PR TITLE
Added missing custom tabs query to manifest

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -39,6 +39,9 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https" />
     </intent>
+    <intent>
+        <action android:name="android.support.customtabs.action.CustomTabsService" />
+    </intent>
   </queries>
 
 </manifest>


### PR DESCRIPTION
This PR supplements PR #613 which accidentally left one query out as originally suggested in https://github.com/openid/AppAuth-Android/issues/599#issue-700154471

The following Intent Action is used to resolve custom tabs service in https://github.com/openid/AppAuth-Android/blob/41a6aa132fa45365aacd1c4b471ccf40670c884c/library/java/net/openid/appauth/browser/BrowserSelector.java#L179 and will fail on Android 11.
```
<intent>
  <action android:name="android.support.customtabs.action.CustomTabsService" />
</intent>
```