### PR TITLE
Restore backwards compatible of configuration constructor

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java
@@ -106,32 +106,50 @@ public class AuthorizationServiceConfiguration {
     public AuthorizationServiceConfiguration(
             @NonNull Uri authorizationEndpoint,
             @NonNull Uri tokenEndpoint) {
-        this(authorizationEndpoint, tokenEndpoint, null, null);
+        this(authorizationEndpoint, tokenEndpoint, null);
     }
 
     /**
      * Creates a service configuration for a basic OAuth2 provider.
-     *  @param authorizationEndpoint The
+     * @param authorizationEndpoint The
      *     [authorization endpoint URI](https://tools.ietf.org/html/rfc6749#section-3.1)
      *     for the service.
      * @param tokenEndpoint The
      *     [token endpoint URI](https://tools.ietf.org/html/rfc6749#section-3.2)
      *     for the service.
-     * @param endSessionEndpoint The
-     *      [end session endpoint URI](https://tools.ietf.org/html/rfc6749#section-2.2)
-     *      for the service.
      * @param registrationEndpoint The optional
      *     [client registration endpoint URI](https://tools.ietf.org/html/rfc7591#section-3)
      */
     public AuthorizationServiceConfiguration(
             @NonNull Uri authorizationEndpoint,
             @NonNull Uri tokenEndpoint,
-            @Nullable Uri endSessionEndpoint,
             @Nullable Uri registrationEndpoint) {
+        this(authorizationEndpoint, tokenEndpoint, registrationEndpoint, null);
+    }
+
+    /**
+     * Creates a service configuration for a basic OAuth2 provider.
+     * @param authorizationEndpoint The
+     *     [authorization endpoint URI](https://tools.ietf.org/html/rfc6749#section-3.1)
+     *     for the service.
+     * @param tokenEndpoint The
+     *     [token endpoint URI](https://tools.ietf.org/html/rfc6749#section-3.2)
+     *     for the service.
+     * @param registrationEndpoint The optional
+     *     [client registration endpoint URI](https://tools.ietf.org/html/rfc7591#section-3)
+     * @param endSessionEndpoint The optional
+     *     [end session endpoint URI](https://tools.ietf.org/html/rfc6749#section-2.2)
+     *     for the service.
+     */
+    public AuthorizationServiceConfiguration(
+            @NonNull Uri authorizationEndpoint,
+            @NonNull Uri tokenEndpoint,
+            @Nullable Uri registrationEndpoint,
+            @Nullable Uri endSessionEndpoint) {
         this.authorizationEndpoint = checkNotNull(authorizationEndpoint);
         this.tokenEndpoint = checkNotNull(tokenEndpoint);
-        this.endSessionEndpoint = endSessionEndpoint;
         this.registrationEndpoint = registrationEndpoint;
+        this.endSessionEndpoint = endSessionEndpoint;
         this.discoveryDoc = null;
     }
 
@@ -162,10 +180,11 @@ public class AuthorizationServiceConfiguration {
         if (registrationEndpoint != null) {
             JsonUtil.put(json, KEY_REGISTRATION_ENDPOINT, registrationEndpoint.toString());
         }
+        if (endSessionEndpoint != null) {
+            JsonUtil.put(json, KEY_END_SESSION_ENPOINT, endSessionEndpoint.toString());
+        }
         if (discoveryDoc != null) {
             JsonUtil.put(json, KEY_DISCOVERY_DOC, discoveryDoc.docJson);
-        } if (endSessionEndpoint != null) {
-            JsonUtil.put(json, KEY_END_SESSION_ENPOINT, endSessionEndpoint.toString());
         }
         return json;
     }
@@ -204,9 +223,8 @@ public class AuthorizationServiceConfiguration {
             return new AuthorizationServiceConfiguration(
                     JsonUtil.getUri(json, KEY_AUTHORIZATION_ENDPOINT),
                     JsonUtil.getUri(json, KEY_TOKEN_ENDPOINT),
-                JsonUtil.getUriIfDefined(json, KEY_END_SESSION_ENPOINT),
-                JsonUtil.getUriIfDefined(json,
-                    KEY_REGISTRATION_ENDPOINT));
+                    JsonUtil.getUriIfDefined(json, KEY_REGISTRATION_ENDPOINT),
+                    JsonUtil.getUriIfDefined(json, KEY_END_SESSION_ENPOINT));
         }
     }
 

--- a/library/java/net/openid/appauth/AuthorizationServiceDiscovery.java
+++ b/library/java/net/openid/appauth/AuthorizationServiceDiscovery.java
@@ -51,7 +51,7 @@ public class AuthorizationServiceDiscovery {
     static final UriField TOKEN_ENDPOINT = uri("token_endpoint");
 
     @VisibleForTesting
-    static final UriField END_SESSION_ENPDINT = uri("end_session_endpoint");
+    static final UriField END_SESSION_ENDPOINT = uri("end_session_endpoint");
 
     @VisibleForTesting
     static final UriField USERINFO_ENDPOINT = uri("userinfo_endpoint");
@@ -265,7 +265,7 @@ public class AuthorizationServiceDiscovery {
      * The OAuth 2 emd session endpoint URI. Not specified test OAuth implementation
      */
     public Uri getEndSessionEndpoint() {
-        return get(END_SESSION_ENPDINT);
+        return get(END_SESSION_ENDPOINT);
     }
 
     /**

--- a/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceConfigurationTest.java
@@ -70,6 +70,7 @@ public class AuthorizationServiceConfigurationTest {
             + " \"authorization_endpoint\": \"" + TEST_AUTH_ENDPOINT + "\",\n"
             + " \"token_endpoint\": \"" + TEST_TOKEN_ENDPOINT + "\",\n"
             + " \"registration_endpoint\": \"" + TEST_REGISTRATION_ENDPOINT + "\",\n"
+            + " \"end_session_endpoint\": \"" + TEST_END_SESSION_ENDPOINT + "\",\n"
             + " \"userinfo_endpoint\": \"" + TEST_USERINFO_ENDPOINT + "\",\n"
             + " \"jwks_uri\": \"" + TEST_JWKS_URI + "\",\n"
             + " \"response_types_supported\": " + toJson(TEST_RESPONSE_TYPE_SUPPORTED) + ",\n"
@@ -117,8 +118,8 @@ public class AuthorizationServiceConfigurationTest {
         mConfig = new AuthorizationServiceConfiguration(
                 Uri.parse(TEST_AUTH_ENDPOINT),
                 Uri.parse(TEST_TOKEN_ENDPOINT),
-                Uri.parse(TEST_END_SESSION_ENDPOINT),
-                Uri.parse(TEST_REGISTRATION_ENDPOINT));
+                Uri.parse(TEST_REGISTRATION_ENDPOINT),
+                Uri.parse(TEST_END_SESSION_ENDPOINT));
         when(mConnectionBuilder.openConnection(any(Uri.class))).thenReturn(mHttpConnection);
     }
 
@@ -139,13 +140,14 @@ public class AuthorizationServiceConfigurationTest {
         AuthorizationServiceConfiguration config = new AuthorizationServiceConfiguration(
                 Uri.parse(TEST_AUTH_ENDPOINT),
                 Uri.parse(TEST_TOKEN_ENDPOINT),
-                Uri.parse(TEST_END_SESSION_ENDPOINT), null);
+                null,
+                Uri.parse(TEST_END_SESSION_ENDPOINT));
         AuthorizationServiceConfiguration deserialized = AuthorizationServiceConfiguration
                 .fromJson(config.toJson());
         assertThat(deserialized.authorizationEndpoint).isEqualTo(config.authorizationEndpoint);
         assertThat(deserialized.tokenEndpoint).isEqualTo(config.tokenEndpoint);
-        assertThat(deserialized.endSessionEndpoint).isEqualTo(config.endSessionEndpoint);
         assertThat(deserialized.registrationEndpoint).isNull();
+        assertThat(deserialized.endSessionEndpoint).isEqualTo(config.endSessionEndpoint);
     }
 
     @Test
@@ -183,6 +185,7 @@ public class AuthorizationServiceConfigurationTest {
         assertEquals(TEST_AUTH_ENDPOINT, config.authorizationEndpoint.toString());
         assertEquals(TEST_TOKEN_ENDPOINT, config.tokenEndpoint.toString());
         assertEquals(TEST_REGISTRATION_ENDPOINT, config.registrationEndpoint.toString());
+        assertEquals(TEST_END_SESSION_ENDPOINT, config.endSessionEndpoint.toString());
     }
 
     @Test


### PR DESCRIPTION
End-session support (#525) introduced a new parameter to AuthorizationServiceConfiguration and broke backwards compatibility.
This change restores registrationEndpoint to 3rd position in constructor and reintroduces the 3 parameter constructor.

Thanks @chrisbanes for noticing.