### PR TITLE
Add note to README.md to remind about persisting fresh tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ authState.performActionWithFreshTokens(service, new AuthStateAction() {
 });
 ```
 
+This also updates the AuthState object with current access, id, and refresh tokens.
+If you are storing your AuthState in persistent storage, you should write the updated
+copy in the callback to this method.
+
 ### Ending current session
 
 Given you have a logged in session and you want to end it. In that case you need to get:


### PR DESCRIPTION
<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [x] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [x] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [x] I updated the documentation if necessary.

### Motivation and Context
Had an issue using this library for the first time by forgetting to update the persisted authstate after using fresh tokens, especially when integrating with services that have single-use refresh tokens.

### Description
Adds a note to the documentation to help people know that this is required.
