### PR TITLE
Made IdToken public and added way to retrieve additionalClaims from it

### DIFF
--- a/library/java/net/openid/appauth/IdToken.java
+++ b/library/java/net/openid/appauth/IdToken.java
@@ -22,7 +22,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import net.openid.appauth.AuthorizationException.GeneralErrors;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -94,7 +93,7 @@ public class IdToken {
     }
 
     private static JSONObject parseJwtSection(String section) throws JSONException {
-        byte[] decodedSection = Base64.decode(section,Base64.URL_SAFE);
+        byte[] decodedSection = Base64.decode(section, Base64.URL_SAFE);
         String jsonString = new String(decodedSection);
         return new JSONObject(jsonString);
     }
@@ -110,8 +109,8 @@ public class IdToken {
         parseJwtSection(sections[0]);
         JSONObject claims = parseJwtSection(sections[1]);
 
-        String issuer = JsonUtil.getString(claims, KEY_ISSUER);
-        String subject = JsonUtil.getString(claims, KEY_SUBJECT);
+        final String issuer = JsonUtil.getString(claims, KEY_ISSUER);
+        final String subject = JsonUtil.getString(claims, KEY_SUBJECT);
         List<String> audience;
         try {
             audience = JsonUtil.getStringList(claims, KEY_AUDIENCE);
@@ -119,10 +118,10 @@ public class IdToken {
             audience = new ArrayList<>();
             audience.add(JsonUtil.getString(claims, KEY_AUDIENCE));
         }
-        Long expiration = claims.getLong(KEY_EXPIRATION);
-        Long issuedAt = claims.getLong(KEY_ISSUED_AT);
-        String nonce = JsonUtil.getStringIfDefined(claims, KEY_NONCE);
-        String authorizedParty = JsonUtil.getStringIfDefined(claims, KEY_AUTHORIZED_PARTY);
+        final Long expiration = claims.getLong(KEY_EXPIRATION);
+        final Long issuedAt = claims.getLong(KEY_ISSUED_AT);
+        final String nonce = JsonUtil.getStringIfDefined(claims, KEY_NONCE);
+        final String authorizedParty = JsonUtil.getStringIfDefined(claims, KEY_AUTHORIZED_PARTY);
 
         claims.remove(KEY_ISSUER);
         claims.remove(KEY_SUBJECT);
@@ -252,10 +251,10 @@ public class IdToken {
         }
     }
 
-    public static Map<String, Object> toMap(JSONObject jsonObj)  throws JSONException {
+    public static Map<String, Object> toMap(JSONObject jsonObj) throws JSONException {
         Map<String, Object> map = new HashMap<>();
         Iterator<String> keys = jsonObj.keys();
-        while(keys.hasNext()) {
+        while (keys.hasNext()) {
             String key = keys.next();
             Object value = jsonObj.get(key);
             if (value instanceof JSONArray) {
@@ -264,20 +263,21 @@ public class IdToken {
                 value = toMap((JSONObject) value);
             }
             map.put(key, value);
-        }   return map;
+        }
+        return map;
     }
 
     public static List<Object> toList(JSONArray array) throws JSONException {
         List<Object> list = new ArrayList<>();
-        for(int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.length(); i++) {
             Object value = array.get(i);
             if (value instanceof JSONArray) {
                 value = toList((JSONArray) value);
-            }
-            else if (value instanceof JSONObject) {
+            } else if (value instanceof JSONObject) {
                 value = toMap((JSONObject) value);
             }
             list.add(value);
-        }   return list;
+        }
+        return list;
     }
 }

--- a/library/java/net/openid/appauth/IdToken.java
+++ b/library/java/net/openid/appauth/IdToken.java
@@ -98,7 +98,7 @@ public class IdToken {
         return new JSONObject(jsonString);
     }
 
-    static IdToken from(String token) throws JSONException, IdTokenException {
+    public static IdToken from(String token) throws JSONException, IdTokenException {
         String[] sections = token.split("\\.");
 
         if (sections.length <= 1) {
@@ -251,7 +251,7 @@ public class IdToken {
         }
     }
 
-    public static Map<String, Object> toMap(JSONObject jsonObj) throws JSONException {
+    static Map<String, Object> toMap(JSONObject jsonObj) throws JSONException {
         Map<String, Object> map = new HashMap<>();
         Iterator<String> keys = jsonObj.keys();
         while (keys.hasNext()) {
@@ -267,7 +267,7 @@ public class IdToken {
         return map;
     }
 
-    public static List<Object> toList(JSONArray array) throws JSONException {
+    static List<Object> toList(JSONArray array) throws JSONException {
         List<Object> list = new ArrayList<>();
         for (int i = 0; i < array.length(); i++) {
             Object value = array.get(i);

--- a/library/javatests/net/openid/appauth/IdTokenTest.java
+++ b/library/javatests/net/openid/appauth/IdTokenTest.java
@@ -5,7 +5,10 @@ import android.util.Base64;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import net.openid.appauth.AuthorizationServiceDiscovery.MissingArgumentException;
 import net.openid.appauth.IdToken.IdTokenException;
 import org.json.JSONArray;
@@ -162,12 +165,14 @@ public class IdTokenTest {
     public void testValidate_withoutNonce() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
         TokenRequest tokenRequest = getTestAuthCodeExchangeRequestBuilder().build();
         Clock clock = SystemClock.INSTANCE;
@@ -178,12 +183,14 @@ public class IdTokenTest {
     public void testValidate_shouldFailOnIssuerMismatch() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             "https://other.issuer",
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
@@ -195,12 +202,14 @@ public class IdTokenTest {
         throws AuthorizationException, JSONException, MissingArgumentException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             "http://other.issuer",
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
 
         String serviceDocJsonWithOtherIssuer = getDiscoveryDocJsonWithIssuer("http://other.issuer");
@@ -223,12 +232,14 @@ public class IdTokenTest {
         throws AuthorizationException, JSONException, MissingArgumentException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             "http://other.issuer",
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
 
         String serviceDocJsonWithOtherIssuer = getDiscoveryDocJsonWithIssuer("http://other.issuer");
@@ -251,12 +262,14 @@ public class IdTokenTest {
         throws AuthorizationException, JSONException, MissingArgumentException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             "https://",
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
 
         String serviceDocJsonWithIssuerMissingHost = getDiscoveryDocJsonWithIssuer("https://");
@@ -279,12 +292,14 @@ public class IdTokenTest {
         throws AuthorizationException, JSONException, MissingArgumentException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             "https://some.issuer?param=value",
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
 
         String serviceDocJsonWithIssuerMissingHost = getDiscoveryDocJsonWithIssuer(
@@ -308,12 +323,14 @@ public class IdTokenTest {
         throws AuthorizationException, JSONException, MissingArgumentException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             "https://some.issuer/#/fragment",
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
 
         String serviceDocJsonWithIssuerMissingHost = getDiscoveryDocJsonWithIssuer(
@@ -336,12 +353,14 @@ public class IdTokenTest {
     public void testValidate_audienceMatch() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
         TokenRequest tokenRequest = getTestAuthCodeExchangeRequest();
         Clock clock = SystemClock.INSTANCE;
@@ -352,12 +371,14 @@ public class IdTokenTest {
     public void testValidate_shouldFailOnAudienceMismatch() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
             Collections.singletonList("some_other_audience"),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
@@ -368,6 +389,7 @@ public class IdTokenTest {
     public void testValidate_authorizedPartyMatch() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
@@ -375,7 +397,8 @@ public class IdTokenTest {
             nowInSeconds + tenMinutesInSeconds,
             nowInSeconds,
             TEST_NONCE,
-            TEST_CLIENT_ID
+            TEST_CLIENT_ID,
+            additionalClaims
         );
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
@@ -387,6 +410,7 @@ public class IdTokenTest {
             throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
@@ -394,7 +418,8 @@ public class IdTokenTest {
             nowInSeconds + tenMinutesInSeconds,
             nowInSeconds,
             TEST_NONCE,
-            "some_other_party"
+            "some_other_party",
+            additionalClaims
         );
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
@@ -405,12 +430,14 @@ public class IdTokenTest {
     public void testValidate_shouldFailOnExpiredToken() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds - tenMinutesInSeconds,
-            nowInSeconds
+            nowInSeconds,
+            additionalClaims
         );
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
@@ -421,12 +448,14 @@ public class IdTokenTest {
     public void testValidate_shouldFailOnIssuedAtOverTenMinutesAgo() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
             Collections.singletonList(TEST_CLIENT_ID),
             nowInSeconds + tenMinutesInSeconds,
-            nowInSeconds - (tenMinutesInSeconds * 2)
+            nowInSeconds - (tenMinutesInSeconds * 2),
+            additionalClaims
         );
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
@@ -437,6 +466,7 @@ public class IdTokenTest {
     public void testValidate_shouldFailOnNonceMismatch() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         IdToken idToken = new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
@@ -444,7 +474,8 @@ public class IdTokenTest {
             nowInSeconds + tenMinutesInSeconds,
             nowInSeconds,
             "some_other_nonce",
-            null
+            null,
+            additionalClaims
         );
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
@@ -482,6 +513,7 @@ public class IdTokenTest {
     private static IdToken getValidIdToken() {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
         Long tenMinutesInSeconds = (long) (10 * 60);
+        Map<String, Object> additionalClaims = new HashMap<>();
         return new IdToken(
             TEST_ISSUER,
             TEST_SUBJECT,
@@ -489,7 +521,8 @@ public class IdTokenTest {
             nowInSeconds + tenMinutesInSeconds,
             nowInSeconds,
             TEST_NONCE,
-            TEST_CLIENT_ID
+            TEST_CLIENT_ID,
+            additionalClaims
         );
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [x] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [ ] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [ ] I updated the documentation if necessary.

### Motivation and Context
IdToken is currently private so it cannot be used to decode/retrieve specific token ("jti" for example)
### Description

This change will address https://github.com/openid/AppAuth-Android/issues/759