### PR TITLE
Add FLAG_ACTIVITY_NEW_TASK when context is not an Activity to prevent crashing

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -19,6 +19,7 @@ import android.app.PendingIntent;
 import android.app.PendingIntent.CanceledException;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -200,7 +201,28 @@ public class AuthorizationManagementActivity extends AppCompatActivity {
     }
 
     private static Intent createBaseIntent(Context context) {
-        return new Intent(context, AuthorizationManagementActivity.class);
+        Intent intent = new Intent(context, AuthorizationManagementActivity.class);
+
+        /*
+         * Starting an activity from a non-activity context will result in a crash as it needs the
+         * FLAG_ACTIVITY_NEW_TASK flag. We make sure we are not working with a wrapped context by
+         * unpacking it, and if it's not an Activity context we will add the NEW_TASK flag.
+         */
+        boolean isActivity = false;
+        Context baseContext = context;
+        while (baseContext instanceof ContextWrapper) {
+            if (baseContext instanceof Activity) {
+                isActivity = true;
+                break;
+            }
+            baseContext = ((ContextWrapper) baseContext).getBaseContext();
+        }
+
+        if (!isActivity) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        }
+
+        return intent;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [x] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. --> (I signed them, but I'm not sure where this link can be found)
- [x] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [x] I updated the documentation if necessary.

### Motivation and Context
In our project we work with clean architecture. Where we access the auth service we don't have access to an Activity context but just the ApplicationContext. When we do perform requests with the Application Context, AppAuth will crash as the intent created needs the FLAG_ACTIVITY_NEW_TASK flag.

### Description
The change is minor. If the context is not an Activity we add the FLAG_ACTIVITY_NEW_TASK flag. We try to be as conservative as possible with this by unwrapping the Context if it's a ContextWrapper and checking the root. (As startIntent will be delegated upwards by ContextWrapper to the parent Context as well).
