### PR TITLE
issue-769 - Add extra configChanges specifier to appauth.Authorizatio…

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -20,6 +20,7 @@
   <application>
     <activity android:name=".AuthorizationManagementActivity"
       android:exported="false"
+      android:configChanges="orientation|screenSize"
       android:theme="@style/Theme.AppCompat.Translucent.NoTitleBar"
       android:launchMode="singleTask" />
 


### PR DESCRIPTION
Add extra **configChanges** specifier to **appauth.AuthorizationManagementActivity** via manifest to fix incorrect 'cancel' response that triggers if an orientation update occurs when returning to the calling activity app on Android 12

### Checklist
- [X] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [X] I signed the CLA and WG Agreements 
- [X] I ran unit tests as necessary.
- [x] I updated and added unit tests as necessary.
- [X] I verified the contribution matches existing coding style.
- [X] I updated the documentation if necessary.

### Motivation and Context

Logins are failing on Android 12 if the browser that pops up is of a different orientation to that of the orientation of the activity that calls it.

### Description

Android 12 has changed its (undefined in doc as far as I could determine) behaviour of the order in which 'onResume' and 'onCreate' occurs after a rotation orientation app restart, which is conflicting with the logic handling in AuthorizationManagementActivity, and inadvertently triggering a 'cancel' response.

This can be reproduced if the web browser that pops up for authentication is of a different orientation than the activity that is calling it.

Thankfully this means the fix is simple - we just need to indicate to the Android OS via the manifest that we do not wish the app to restart the running activity (AuthorizationManagementActivity) on a rotation update event, by specifying in the manifest.

We have implemented this fix in our app by modifying the entry in our own manifest file, and we are seeing no issues with it in live production. 