### PR TITLE
Add form_post response mode

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationRequest.java
+++ b/library/java/net/openid/appauth/AuthorizationRequest.java
@@ -264,6 +264,14 @@ public class AuthorizationRequest implements AuthorizationManagementRequest {
          * <http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#rfc.section.2.1>"
          */
         public static final String FRAGMENT = "fragment";
+
+        /**
+         * Instructs the authorization server to send response parameters using
+         * the HTTP POST method.
+         * @see "OAuth 2.0 Multiple Response Type Encoding Practices, Section 2.1
+         * <https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html>"
+         */
+        public static final String FORM_POST = "form_post";
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [x] I signed the CLA and WG Agreements 
- [ ] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [ ] I updated the documentation if necessary.

>Please provide link if this is your first contribution

Not sure which link is needed. I signed both documents.

### Motivation and Context
Sign in with Apple requires the `form_post` response method.

Spec:
https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html

### Description
Adds a FORM_POST constant.