### PR TITLE
Change or skip allowed time skew for ID token issue time validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ AppAuthConfiguration appAuthConfig = new AppAuthConfiguration.Builder()
 
 ID Token validation was introduced in `0.8.0` but not all authorization servers or configurations support it correctly.
 
-- For testing environments [setSkipIssuerHttpsCheck](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AppAuthConfiguration.java#L129) can be used to bypass the fact the issuer needs to be HTTPS.
+- For testing environments [setSkipIssuerHttpsCheck](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AppAuthConfiguration.java#L143) can be used to bypass the fact the issuer needs to be HTTPS.
 
 ```java
 AppAuthConfiguration appAuthConfig = new AppAuthConfiguration.Builder()
@@ -633,6 +633,22 @@ AppAuthConfiguration appAuthConfig = new AppAuthConfiguration.Builder()
 AuthorizationRequest authRequest = authRequestBuilder
     .setNonce(null)
     .build();
+```
+
+- To change the default allowed time skew of 10 minutes for the issue time, [setAllowedIssueTimeSkew](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AppAuthConfiguration.java#L159) can be used.
+
+```java
+AppAuthConfiguration appAuthConfig = new AppAuthConfiguration.Builder()
+    .setAllowedIssueTimeSkew(THIRTY_MINUTES_IN_SECONDS)
+    .build()
+```
+
+- For testing environments [setSkipIssueTimeValidation](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AppAuthConfiguration.java#L151) can be used to bypass the issue time validation.
+
+```java
+AppAuthConfiguration appAuthConfig = new AppAuthConfiguration.Builder()
+    .setSkipIssueTimeValidation(true)
+    .build()
 ```
 
 ## Dynamic client registration

--- a/library/java/net/openid/appauth/AppAuthConfiguration.java
+++ b/library/java/net/openid/appauth/AppAuthConfiguration.java
@@ -42,13 +42,21 @@ public class AppAuthConfiguration {
 
     private final boolean mSkipIssuerHttpsCheck;
 
+    private final boolean mSkipIssueTimeValidation;
+
+    private final Long mAllowedIssueTimeSkew;
+
     private AppAuthConfiguration(
             @NonNull BrowserMatcher browserMatcher,
             @NonNull ConnectionBuilder connectionBuilder,
-            Boolean skipIssuerHttpsCheck) {
+            Boolean skipIssuerHttpsCheck,
+            Boolean skipIssueTimeValidation,
+            Long allowedIssueTimeSkew) {
         mBrowserMatcher = browserMatcher;
         mConnectionBuilder = connectionBuilder;
         mSkipIssuerHttpsCheck = skipIssuerHttpsCheck;
+        mSkipIssueTimeValidation = skipIssueTimeValidation;
+        mAllowedIssueTimeSkew = allowedIssueTimeSkew;
     }
 
     /**
@@ -77,6 +85,22 @@ public class AppAuthConfiguration {
     public boolean getSkipIssuerHttpsCheck() { return mSkipIssuerHttpsCheck; }
 
     /**
+     * Returns <code>true</code> if the ID token issue time validation is disables,
+     * otherwise <code>false</code>.
+     *
+     * @see Builder#setSkipIssueTimeValidation(Boolean)
+     */
+    public boolean getSkipIssueTimeValidation() { return mSkipIssueTimeValidation; }
+
+    /**
+     * Returns the time in seconds that the ID token issue time is allowed to be
+     * skewed.
+     *
+     * @see Builder#setAllowedIssueTimeSkew(Long)
+     */
+    public Long getAllowedIssueTimeSkew() { return mAllowedIssueTimeSkew; }
+
+    /**
      * Creates {@link AppAuthConfiguration} instances.
      */
     public static class Builder {
@@ -84,6 +108,8 @@ public class AppAuthConfiguration {
         private BrowserMatcher mBrowserMatcher = AnyBrowserMatcher.INSTANCE;
         private ConnectionBuilder mConnectionBuilder = DefaultConnectionBuilder.INSTANCE;
         private boolean mSkipIssuerHttpsCheck;
+        private boolean mSkipIssueTimeValidation;
+        private Long mAllowedIssueTimeSkew;
         private boolean mSkipNonceVerification;
 
         /**
@@ -120,6 +146,22 @@ public class AppAuthConfiguration {
         }
 
         /**
+         * Disables issue time validation for the id token.
+         */
+        public Builder setSkipIssueTimeValidation(Boolean skipIssueTimeValidation) {
+            mSkipIssueTimeValidation = skipIssueTimeValidation;
+            return this;
+        }
+
+        /**
+         * Sets the allowed time skew in seconds for id token issue time validation.
+         */
+        public Builder setAllowedIssueTimeSkew(Long allowedIssueTimeSkew) {
+            mAllowedIssueTimeSkew = allowedIssueTimeSkew;
+            return this;
+        }
+
+        /**
          * Creates the instance from the configured properties.
          */
         @NonNull
@@ -127,7 +169,9 @@ public class AppAuthConfiguration {
             return new AppAuthConfiguration(
                 mBrowserMatcher,
                 mConnectionBuilder,
-                mSkipIssuerHttpsCheck
+                mSkipIssuerHttpsCheck,
+                mSkipIssueTimeValidation,
+                mAllowedIssueTimeSkew
             );
         }
 

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -506,7 +506,9 @@ public class AuthorizationService {
                 mClientConfiguration.getConnectionBuilder(),
                 SystemClock.INSTANCE,
                 callback,
-                mClientConfiguration.getSkipIssuerHttpsCheck())
+                mClientConfiguration.getSkipIssuerHttpsCheck(),
+                mClientConfiguration.getSkipIssueTimeValidation(),
+                mClientConfiguration.getAllowedIssueTimeSkew())
                 .execute();
     }
 
@@ -585,6 +587,8 @@ public class AuthorizationService {
         private TokenResponseCallback mCallback;
         private Clock mClock;
         private boolean mSkipIssuerHttpsCheck;
+        private boolean mSkipIssueTimeValidation;
+        private Long mAllowedIssueTimeSkew;
 
         private AuthorizationException mException;
 
@@ -593,13 +597,17 @@ public class AuthorizationService {
                          @NonNull ConnectionBuilder connectionBuilder,
                          Clock clock,
                          TokenResponseCallback callback,
-                         Boolean skipIssuerHttpsCheck) {
+                         Boolean skipIssuerHttpsCheck,
+                         Boolean skipissueTimeValidation,
+                         Long allowedIssueTimeSkew) {
             mRequest = request;
             mClientAuthentication = clientAuthentication;
             mConnectionBuilder = connectionBuilder;
             mClock = clock;
             mCallback = callback;
             mSkipIssuerHttpsCheck = skipIssuerHttpsCheck;
+            mSkipIssueTimeValidation = skipissueTimeValidation;
+            mAllowedIssueTimeSkew = allowedIssueTimeSkew;
         }
 
         @Override
@@ -710,7 +718,9 @@ public class AuthorizationService {
                     idToken.validate(
                             mRequest,
                             mClock,
-                            mSkipIssuerHttpsCheck
+                            mSkipIssuerHttpsCheck,
+                            mSkipIssueTimeValidation,
+                            mAllowedIssueTimeSkew
                     );
                 } catch (AuthorizationException ex) {
                     mCallback.onTokenRequestCompleted(null, ex);

--- a/library/java/net/openid/appauth/IdToken.java
+++ b/library/java/net/openid/appauth/IdToken.java
@@ -204,12 +204,14 @@ public class IdToken {
 
     @VisibleForTesting
     void validate(@NonNull TokenRequest tokenRequest, Clock clock) throws AuthorizationException {
-        validate(tokenRequest, clock, false);
+        validate(tokenRequest, clock, false, false, null);
     }
 
     void validate(@NonNull TokenRequest tokenRequest,
                   Clock clock,
-                  boolean skipIssuerHttpsCheck) throws AuthorizationException {
+                  boolean skipIssuerHttpsCheck,
+                  boolean skipIssueTimeValidation,
+                  @Nullable Long allowedIssueTimeSkew) throws AuthorizationException {
         // OpenID Connect Core Section 3.1.3.7. rule #1
         // Not enforced: AppAuth does not support JWT encryption.
 
@@ -276,13 +278,16 @@ public class IdToken {
                 new IdTokenException("ID Token expired"));
         }
 
-        // OpenID Connect Core Section 3.1.3.7. rule #10
-        // Validates that the issued at time is not more than +/- 10 minutes on the current
-        // time.
-        if (Math.abs(nowInSeconds - this.issuedAt) > TEN_MINUTES_IN_SECONDS) {
-            throw AuthorizationException.fromTemplate(GeneralErrors.ID_TOKEN_VALIDATION_ERROR,
-                new IdTokenException("Issued at time is more than 10 minutes "
-                    + "before or after the current time"));
+
+        if (!skipIssueTimeValidation) {
+            // OpenID Connect Core Section 3.1.3.7. rule #10
+            // Validates that the issued at time is not more than the +/- configured allowed time skew,
+            // or +/- 10 minutes as a default, on the current time.
+            if (Math.abs(nowInSeconds - this.issuedAt) > (allowedIssueTimeSkew == null ? TEN_MINUTES_IN_SECONDS : allowedIssueTimeSkew)) {
+                throw AuthorizationException.fromTemplate(GeneralErrors.ID_TOKEN_VALIDATION_ERROR,
+                    new IdTokenException("Issued at time is more than 10 minutes "
+                        + "before or after the current time"));
+            }
         }
 
         // Only relevant for the authorization_code response type

--- a/library/javatests/net/openid/appauth/IdTokenTest.java
+++ b/library/javatests/net/openid/appauth/IdTokenTest.java
@@ -272,7 +272,7 @@ public class IdTokenTest {
             .setRedirectUri(TEST_APP_REDIRECT_URI)
             .build();
         Clock clock = SystemClock.INSTANCE;
-        idToken.validate(tokenRequest, clock, true);
+        idToken.validate(tokenRequest, clock, true, false, null);
     }
 
     @Test(expected = AuthorizationException.class)
@@ -462,6 +462,60 @@ public class IdTokenTest {
         TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
         Clock clock = SystemClock.INSTANCE;
         idToken.validate(tokenRequest, clock);
+    }
+
+    @Test
+    public void testValidate_withSkipIssueTimeValidation() throws AuthorizationException {
+        Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
+        Long anHourInSeconds = (long) (60 * 60);
+        IdToken idToken = new IdToken(
+            TEST_ISSUER,
+            TEST_SUBJECT,
+            Collections.singletonList(TEST_CLIENT_ID),
+            nowInSeconds,
+            nowInSeconds - (anHourInSeconds * 2),
+            TEST_NONCE,
+            TEST_CLIENT_ID
+        );
+        TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
+        Clock clock = SystemClock.INSTANCE;
+        idToken.validate(tokenRequest, clock, false, true, null);
+    }
+
+    @Test(expected = AuthorizationException.class)
+    public void testValidate_shouldFailOnIssuedAtOverConfiguredTimeSkew() throws AuthorizationException {
+        Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
+        Long anHourInSeconds = (long) (60 * 60);
+        IdToken idToken = new IdToken(
+            TEST_ISSUER,
+            TEST_SUBJECT,
+            Collections.singletonList(TEST_CLIENT_ID),
+            nowInSeconds,
+            nowInSeconds - anHourInSeconds - 1,
+            TEST_NONCE,
+            TEST_CLIENT_ID
+        );
+        TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
+        Clock clock = SystemClock.INSTANCE;
+        idToken.validate(tokenRequest, clock, false, false, anHourInSeconds);
+    }
+
+    @Test
+    public void testValidate_withConfiguredTimeSkew() throws AuthorizationException {
+        Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
+        Long anHourInSeconds = (long) (60 * 60);
+        IdToken idToken = new IdToken(
+            TEST_ISSUER,
+            TEST_SUBJECT,
+            Collections.singletonList(TEST_CLIENT_ID),
+            nowInSeconds,
+            nowInSeconds - anHourInSeconds,
+            TEST_NONCE,
+            TEST_CLIENT_ID
+        );
+        TokenRequest tokenRequest = getAuthCodeExchangeRequestWithNonce();
+        Clock clock = SystemClock.INSTANCE;
+        idToken.validate(tokenRequest, clock, false, false, anHourInSeconds);
     }
 
     @Test(expected = AuthorizationException.class)


### PR DESCRIPTION
<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [x] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [x] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [x] I updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? If it addreses an existing issue pleaase provide a link. -->

Change aims to address issue in #830 by adding the ability to either disable or change the allowed time skew for the ID Token issued at time (`iat`). Changing the allowed time skew can be useful because the clock on some devices can go beyond the default of 10 minutes. The OIDC specs do not define a specific timeframe, and the default of 10 minutes is still used when the new options are not used.

### Description
<!-- Describe your changes in detail. -->

I followed a similar approach as #662 already did for skipping the issuer https check.

- To change the default allowed time skew of 10 minutes for the issue time, [setAllowedIssueTimeSkew](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AppAuthConfiguration.java#L159) can be used.

```java
AppAuthConfiguration appAuthConfig = new AppAuthConfiguration.Builder()
    .setAllowedIssueTimeSkew(THIRTY_MINUTES_IN_SECONDS)
    .build()
```

- For testing environments [setSkipIssueTimeValidation](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AppAuthConfiguration.java#L151) can be used to bypass the issue time validation.

```java
AppAuthConfiguration appAuthConfig = new AppAuthConfiguration.Builder()
    .setSkipIssueTimeValidation(true)
    .build()
```