### PR TITLE
Improve error logging when sending the result via PendingIntent fails

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -327,15 +327,15 @@ public class AuthorizationManagementActivity extends AppCompatActivity {
         }
     }
 
-    private void sendResult(PendingIntent callback, Intent cancelData, int resultCode) {
+    private void sendResult(PendingIntent callback, Intent intentData, int resultCode) {
         if (callback != null) {
             try {
-                callback.send(this, 0, cancelData);
+                callback.send(this, 0, intentData);
             } catch (CanceledException e) {
-                Logger.error("Failed to send cancel intent", e);
+                Logger.errorWithStack(e, "Failed to send intent");
             }
         } else {
-            setResult(resultCode, cancelData);
+            setResult(resultCode, intentData);
         }
     }
 


### PR DESCRIPTION
Update the error message not to mention cancelling, as the `sendResult()` method is used for sending the completion intent as well, and also include the exception stack trace.

<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [ ] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [x] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [x] I updated the documentation if necessary.

### Motivation and Context
The `sendResult()` method is used for sending the completion intent as well as the cancellation intent, but its error message only mentions cancellation, which can be confusing. In addition, the additional exception parameter passed to `Logger.error()` is ignored.

### Description
Update the error message not to mention cancelling, and also include the exception stack trace.
