### PR TITLE
Add "create" prompt to open registration page

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationRequest.java
+++ b/library/java/net/openid/appauth/AuthorizationRequest.java
@@ -171,6 +171,17 @@ public class AuthorizationRequest implements AuthorizationManagementRequest {
          * <https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.6>"
          */
         public static final String SELECT_ACCOUNT = "select_account";
+
+        /**
+         * A value of create indicates to the OpenID Provider that the client desires that the user
+         * be shown the account creation UX rather than the login flow. Care must be taken if
+         * combining this value with other prompt values. Mutually exclusive conditions can
+         * arise so it is RECOMMENDED that create not be combined with any other values.
+         *
+         * @see "Initiating User Registration via OpenID Connect 1.0
+         * <https://openid.net/specs/openid-connect-prompt-create-1_0-final.html>"
+         */
+        public static final String CREATE = "create";
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [x] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [x] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [x] I updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? If it addresses an existing issue please provide a link. -->

For a long time there were lots of hacks to open registration page directly. Now, we have a standard that is supported by a majority of authorization servers. That's why I'm extending AppAuth with another prompt value from OIDC spec ([link](https://openid.net/specs/openid-connect-prompt-create-1_0.html)) described in issue https://github.com/openid/AppAuth-Android/issues/1134. 

Many users already use this prompt parameter, so the idea is to extend the library to:
- standardize the set of allowed prompt values
- add extensive documentation for newcomers with link to specs (as we do it for other values)
- align AppAuth with real-world OIDC implementations (Keycloak, Auth0, etc.)

### Description
<!-- Describe your changes in detail. -->

This solution allows to use predefined prompt to open registration page directly in `AuthorizationRequest`:

<img width="553" height="231" alt="Знімок екрана 2025-07-16 о 00 24 45" src="https://github.com/user-attachments/assets/0a82bcab-ef33-45b5-93c8-8f35a344956b" />

