### PR TITLE
Fix of incorrect configuration change validation

### DIFF
--- a/app/java/net/openid/appauthdemo/Configuration.java
+++ b/app/java/net/openid/appauthdemo/Configuration.java
@@ -192,7 +192,9 @@ public final class Configuration {
         Buffer configData = new Buffer();
         try {
             configSource.readAll(configData);
+            final String configHash = configData.sha256().base64();
             mConfigJson = new JSONObject(configData.readString(Charset.forName("UTF-8")));
+            mConfigHash = configHash;
         } catch (IOException ex) {
             throw new InvalidConfigurationException(
                     "Failed to read configuration: " + ex.getMessage());
@@ -201,7 +203,6 @@ public final class Configuration {
                     "Unable to parse configuration: " + ex.getMessage());
         }
 
-        mConfigHash = configData.sha256().base64();
         mClientId = getConfigString("client_id");
         mScope = getRequiredConfigString("authorization_scope");
         mRedirectUri = getRequiredConfigUri("redirect_uri");


### PR DESCRIPTION
### Checklist
- [x] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [x] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [x] I ran, updated and added unit tests as necessary.
- [x] I verified the contribution matches existing coding style.
- [x] I updated the documentation if necessary.

### Motivation and Context
The fix resolves the issue of configuration changes being ignored. Fixing #1011 

### Description
The code uses a hash of the config data to determine whether there have been any changes. But, before calculating the hash, the readString method was called, which left no data in the buffer, resulting in the hash of an empty string being calculated every time.
